### PR TITLE
Update tuple to C++20

### DIFF
--- a/tuple/.clang-tidy
+++ b/tuple/.clang-tidy
@@ -26,12 +26,14 @@ Checks: >
   -cppcoreguidelines-narrowing-conversions,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
   -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -cppcoreguidelines-pro-type-member-init,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   google-*,
   -google-readability-todo,
+  -google-runtime-float,
   -google-runtime-int,
   hicpp-*,
   -hicpp-explicit-conversions,
@@ -48,7 +50,7 @@ Checks: >
   modernize-*,
   -modernize-pass-by-value,
   -modernize-use-auto,
-  -modernize-use-constraints,
+  -modernize-use-integer-sign-comparison,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   performance-*,
@@ -58,23 +60,20 @@ Checks: >
   -portability-avoid-pragma-once,
   -portability-template-virtual-member-function,
   readability-*,
-  -readability-else-after-return,
   -readability-function-cognitive-complexity,
-  -readability-identifier-naming,
   -readability-identifier-length,
   -readability-implicit-bool-conversion,
   -readability-magic-numbers,
   -readability-math-missing-parentheses,
   -readability-named-parameter,
   -readability-redundant-access-specifiers,
-  -readability-use-concise-preprocessor-directives,
-  -cert-oop54-cpp
+  -readability-use-concise-preprocessor-directives
 WarningsAsErrors: '*'
 CheckOptions:
   - key: cppcoreguidelines-rvalue-reference-param-not-moved.AllowPartialMove
     value: 'true'
   - key: readability-identifier-naming.ClassCase
-    value: CamelCase
+    value: lower_case
   - key: readability-identifier-naming.FunctionCase
     value: lower_case
   - key: readability-identifier-naming.FunctionIgnoredRegexp
@@ -88,8 +87,6 @@ CheckOptions:
   - key: readability-identifier-naming.PrivateMemberPrefix
     value: m_
   - key: readability-identifier-naming.StructCase
-    value: CamelCase
-  - key: readability-identifier-naming.StructIgnoredRegexp
-    value: '(is_.*|sum|prod|land|lor|band|bor|bxor|min|max|minmax|coordinate_of|chunk_traits|rebind|kwArgs_fft)'
+    value: lower_case
   - key: readability-identifier-naming.TemplateParameterCase
     value: CamelCase

--- a/tuple/CMakeLists.txt
+++ b/tuple/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(cexa.tuple INTERFACE)
 # )
 target_include_directories(cexa.tuple INTERFACE "${CMAKE_CURRENT_LIST_DIR}/include")
 target_link_libraries(cexa.tuple INTERFACE Kokkos::kokkos)
+target_compile_features(cexa.tuple INTERFACE cxx_std_20)
 add_library(cexa::tuple ALIAS cexa.tuple)
 
 if(CEXA_TUPLE_ENABLE_TESTS)

--- a/tuple/CMakeLists.txt
+++ b/tuple/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CExA-project
+# SPDX-FileCopyrightText: Copyright (C) The CExA project
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 cmake_minimum_required(VERSION 3.22)
 

--- a/tuple/README.md
+++ b/tuple/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 CExA-project
+SPDX-FileCopyrightText: Copyright (C) The CExA project
 
 SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 -->

--- a/tuple/include/impl/apply.hpp
+++ b/tuple/include/impl/apply.hpp
@@ -86,7 +86,7 @@ struct make_tuple_constraint<U, Tuple, 1> {
       U, decltype(get<0>(std::declval<Tuple>()))>;
 };
 
-template <class T, class Tuple, class seq>
+template <class T, class Tuple, class Seq>
 struct is_constructible_from_tuple;
 
 template <class T, class Tuple, std::size_t... Ints>
@@ -132,9 +132,8 @@ KOKKOS_INLINE_FUNCTION constexpr decltype(auto) apply(F&& f, Tuple&& t)
       std::make_index_sequence<tuple_size_v<std::remove_reference_t<Tuple>>>{});
 }
 
-template <
-    class T, class Tuple,
-    class = std::enable_if_t<impl::is_constructible_from_tuple_v<T, Tuple>>>
+template <class T, class Tuple>
+  requires impl::is_constructible_from_tuple_v<T, Tuple>
 KOKKOS_INLINE_FUNCTION constexpr T make_from_tuple(Tuple&& t) {
   static_assert(impl::is_tuple_v<std::remove_cvref_t<Tuple>>,
                 "cexa::make_from_tuple can only be called with cexa::tuple");

--- a/tuple/include/impl/apply.hpp
+++ b/tuple/include/impl/apply.hpp
@@ -9,6 +9,10 @@
 #include "traits.hpp"
 #include "tuple.hpp"
 
+#ifdef CEXA_HAS_CXX23
+#include <functional>
+#endif
+
 namespace cexa {
 
 namespace impl {
@@ -48,6 +52,8 @@ KOKKOS_INLINE_FUNCTION constexpr decltype(auto) invoke_ptr(Pointed C::* member,
   }
 }
 
+// f may be a host function
+CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
 template <class F, class... Args>
 KOKKOS_INLINE_FUNCTION constexpr decltype(auto) invoke(F&& f, Args&&... args) {
   if constexpr (std::is_member_pointer_v<std::remove_cvref_t<F>>) {
@@ -63,6 +69,8 @@ KOKKOS_INLINE_FUNCTION constexpr decltype(auto) apply(
   return invoke(std::forward<F>(f), cexa::get<I>(std::forward<Tuple>(t))...);
 }
 
+// This might call a host only constructor
+CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
 template <class T, class Tuple, std::size_t... I>
 KOKKOS_INLINE_FUNCTION constexpr T make_from_tuple(Tuple&& t,
                                                    std::index_sequence<I...>) {
@@ -93,10 +101,30 @@ inline constexpr bool is_constructible_from_tuple_v =
                                 std::make_index_sequence<tuple_size_v<
                                     std::remove_cvref_t<Tuple>>>>::value;
 
+#ifdef CEXA_HAS_CXX23
+template <class F, class Tuple, class Other>
+struct is_nothrow_applicable : std::false_type {};
+
+template <class F, class Tuple, std::size_t... Is>
+struct is_nothrow_applicable<F, Tuple, std::index_sequence<Is...>> {
+  static constexpr bool value = noexcept(
+      std::invoke(std::declval<F>(), get<Is>(std::declval<Tuple>())...));
+};
+
+template <class F, class Tuple>
+constexpr bool is_nothrow_applicable_v =
+    is_nothrow_applicable<F, Tuple,
+                          decltype(std::make_index_sequence<tuple_size_v<
+                                       std::remove_cvref_t<Tuple>>>{})>::value;
+#endif
 }  // namespace impl
 
 template <class F, class Tuple>
-KOKKOS_INLINE_FUNCTION constexpr decltype(auto) apply(F&& f, Tuple&& t) {
+KOKKOS_INLINE_FUNCTION constexpr decltype(auto) apply(F&& f, Tuple&& t)
+#ifdef CEXA_HAS_CXX23
+    noexcept(impl::is_nothrow_applicable_v<F, Tuple>)
+#endif
+{
   static_assert(impl::is_tuple_v<std::remove_cvref_t<Tuple>>,
                 "cexa::apply can only be called with cexa::tuple");
   return impl::apply(

--- a/tuple/include/impl/apply.hpp
+++ b/tuple/include/impl/apply.hpp
@@ -9,7 +9,7 @@
 #include "traits.hpp"
 #include "tuple.hpp"
 
-#ifdef CEXA_HAS_CXX23
+#if defined(CEXA_HAS_CXX23)
 #include <functional>
 #endif
 
@@ -101,7 +101,7 @@ inline constexpr bool is_constructible_from_tuple_v =
                                 std::make_index_sequence<tuple_size_v<
                                     std::remove_cvref_t<Tuple>>>>::value;
 
-#ifdef CEXA_HAS_CXX23
+#if defined(CEXA_HAS_CXX23)
 template <class F, class Tuple, class Other>
 struct is_nothrow_applicable : std::false_type {};
 
@@ -121,7 +121,7 @@ constexpr bool is_nothrow_applicable_v =
 
 template <class F, class Tuple>
 KOKKOS_INLINE_FUNCTION constexpr decltype(auto) apply(F&& f, Tuple&& t)
-#ifdef CEXA_HAS_CXX23
+#if defined(CEXA_HAS_CXX23)
     noexcept(impl::is_nothrow_applicable_v<F, Tuple>)
 #endif
 {

--- a/tuple/include/impl/apply.hpp
+++ b/tuple/include/impl/apply.hpp
@@ -21,7 +21,7 @@ template <class C, class Pointed, class Object, class... Args>
 KOKKOS_INLINE_FUNCTION constexpr decltype(auto) invoke_ptr(Pointed C::* member,
                                                            Object&& object,
                                                            Args&&... args) {
-  using object_t            = remove_cvref_t<Object>;
+  using object_t            = std::remove_cvref_t<Object>;
   constexpr bool is_wrapped = is_reference_wrapper_v<object_t>;
   constexpr bool is_derived_object =
       std::is_same_v<C, object_t> || std::is_base_of_v<C, object_t>;
@@ -50,7 +50,7 @@ KOKKOS_INLINE_FUNCTION constexpr decltype(auto) invoke_ptr(Pointed C::* member,
 
 template <class F, class... Args>
 KOKKOS_INLINE_FUNCTION constexpr decltype(auto) invoke(F&& f, Args&&... args) {
-  if constexpr (std::is_member_pointer_v<remove_cvref_t<F>>) {
+  if constexpr (std::is_member_pointer_v<std::remove_cvref_t<F>>) {
     return invoke_ptr(f, std::forward<Args>(args)...);
   } else {
     return (std::forward<F>(f))(std::forward<Args>(args)...);
@@ -69,7 +69,7 @@ KOKKOS_INLINE_FUNCTION constexpr T make_from_tuple(Tuple&& t,
   return T(cexa::get<I>(std::forward<Tuple>(t))...);
 }
 
-template <class U, class T, std::size_t = tuple_size_v<impl::remove_cvref_t<T>>>
+template <class U, class T, std::size_t = tuple_size_v<std::remove_cvref_t<T>>>
 struct make_tuple_constraint : std::true_type {};
 
 template <class U, class Tuple>
@@ -91,13 +91,13 @@ template <class T, class Tuple>
 inline constexpr bool is_constructible_from_tuple_v =
     is_constructible_from_tuple<T, Tuple,
                                 std::make_index_sequence<tuple_size_v<
-                                    impl::remove_cvref_t<Tuple>>>>::value;
+                                    std::remove_cvref_t<Tuple>>>>::value;
 
 }  // namespace impl
 
 template <class F, class Tuple>
 KOKKOS_INLINE_FUNCTION constexpr decltype(auto) apply(F&& f, Tuple&& t) {
-  static_assert(impl::is_tuple_v<impl::remove_cvref_t<Tuple>>,
+  static_assert(impl::is_tuple_v<std::remove_cvref_t<Tuple>>,
                 "cexa::apply can only be called with cexa::tuple");
   return impl::apply(
       std::forward<F>(f), std::forward<Tuple>(t),
@@ -108,11 +108,11 @@ template <
     class T, class Tuple,
     class = std::enable_if_t<impl::is_constructible_from_tuple_v<T, Tuple>>>
 KOKKOS_INLINE_FUNCTION constexpr T make_from_tuple(Tuple&& t) {
-  static_assert(impl::is_tuple_v<impl::remove_cvref_t<Tuple>>,
+  static_assert(impl::is_tuple_v<std::remove_cvref_t<Tuple>>,
                 "cexa::make_from_tuple can only be called with cexa::tuple");
   constexpr std::size_t size = tuple_size_v<std::remove_reference_t<Tuple>>;
   static_assert(
-      impl::make_tuple_constraint<T, impl::remove_cvref_t<Tuple>>::value);
+      impl::make_tuple_constraint<T, std::remove_cvref_t<Tuple>>::value);
   return impl::make_from_tuple<T>(std::forward<Tuple>(t),
                                   std::make_index_sequence<size>{});
 }

--- a/tuple/include/impl/apply.hpp
+++ b/tuple/include/impl/apply.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 #pragma once
 

--- a/tuple/include/impl/creation.hpp
+++ b/tuple/include/impl/creation.hpp
@@ -66,6 +66,8 @@ struct cartesian_product
                                  std::remove_reference_t<Tuples>>::value>...> {
 };
 
+// We might call std::get depending on the types in Tuples
+CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
 template <class... Tuples, std::size_t... Ints1, std::size_t... Ints2>
 KOKKOS_FORCEINLINE_FUNCTION constexpr tuple<cexa::tuple_element_t<
     Ints1,

--- a/tuple/include/impl/creation.hpp
+++ b/tuple/include/impl/creation.hpp
@@ -78,8 +78,8 @@ tuple_cat_impl(tuple<Tuples...>&& tuples, std::index_sequence<Ints1...>,
 }
 }  // namespace impl
 
-template <class... Tuples,
-          class = std::enable_if_t<(impl::is_tuple_like<Tuples>::value && ...)>>
+template <class... Tuples>
+  requires(impl::is_tuple_like<Tuples>::value && ...)
 KOKKOS_INLINE_FUNCTION constexpr auto tuple_cat(Tuples&&... tuples) {
   using cartesian_product_t = impl::cartesian_product<Tuples...>;
   return impl::tuple_cat_impl(cexa::forward_as_tuple(tuples...),

--- a/tuple/include/impl/creation.hpp
+++ b/tuple/include/impl/creation.hpp
@@ -13,7 +13,7 @@ namespace cexa {
 
 // tuple.creation
 template <class... TTypes>
-KOKKOS_INLINE_FUNCTION constexpr tuple<impl::unwrap_ref_decay_t<TTypes>...>
+KOKKOS_INLINE_FUNCTION constexpr tuple<std::unwrap_ref_decay_t<TTypes>...>
 make_tuple(TTypes&&... t) {
   return {std::forward<TTypes>(t)...};
 }
@@ -69,7 +69,7 @@ struct cartesian_product
 template <class... Tuples, std::size_t... Ints1, std::size_t... Ints2>
 KOKKOS_FORCEINLINE_FUNCTION constexpr tuple<cexa::tuple_element_t<
     Ints1,
-    impl::remove_cvref_t<cexa::tuple_element_t<Ints2, tuple<Tuples...>>>>...>
+    std::remove_cvref_t<cexa::tuple_element_t<Ints2, tuple<Tuples...>>>>...>
 tuple_cat_impl(tuple<Tuples...>&& tuples, std::index_sequence<Ints1...>,
                std::index_sequence<Ints2...>) {
   return {get<Ints1>(std::move(get<Ints2>(tuples)))...};

--- a/tuple/include/impl/creation.hpp
+++ b/tuple/include/impl/creation.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 #pragma once
 

--- a/tuple/include/impl/helper.hpp
+++ b/tuple/include/impl/helper.hpp
@@ -74,7 +74,7 @@ struct tuple_element<1, std::ranges::subrange<I, S, K>> {
 };
 
 template <std::size_t I, class T>
-using tuple_element_t = typename tuple_element<I, T>::type;
+using tuple_element_t = tuple_element<I, T>::type;
 
 // tuple_size
 template <class T>
@@ -114,7 +114,7 @@ inline constexpr std::size_t tuple_size_v = tuple_size<T>::value;
 
 // NOTE: specializations of std::tuple_size and std::tuple_element for user
 // defined types are allowed.
-// NOLINTBEGIN(cert-dcl58-cpp)
+// NOLINTBEGIN(cert-dcl58-cpp,bugprone-std-namespace-modification)
 template <typename... Types>
 struct std::tuple_size<cexa::tuple<Types...>>
     : std::integral_constant<std::size_t, sizeof...(Types)> {};
@@ -122,4 +122,4 @@ struct std::tuple_size<cexa::tuple<Types...>>
 template <std::size_t I, typename... Types>
 struct std::tuple_element<I, cexa::tuple<Types...>>
     : cexa::tuple_element<I, cexa::tuple<Types...>> {};
-// NOLINTEND(cert-dcl58-cpp)
+// NOLINTEND(cert-dcl58-cpp,bugprone-std-namespace-modification)

--- a/tuple/include/impl/helper.hpp
+++ b/tuple/include/impl/helper.hpp
@@ -5,9 +5,7 @@
 #include <array>
 #include <cstddef>
 #include <type_traits>  // integral_constant
-#if defined(CEXA_HAS_CXX20)
 #include <ranges>
-#endif
 
 #include "tuple_fwd.hpp"
 #include "traits.hpp"
@@ -65,7 +63,6 @@ struct tuple_element<I, std::array<T, N>> {
   using type = T;
 };
 
-#if defined(CEXA_HAS_CXX20)
 template <class I, class S, std::ranges::subrange_kind K>
 struct tuple_element<0, std::ranges::subrange<I, S, K>> {
   using type = I;
@@ -75,7 +72,6 @@ template <class I, class S, std::ranges::subrange_kind K>
 struct tuple_element<1, std::ranges::subrange<I, S, K>> {
   using type = S;
 };
-#endif
 
 template <std::size_t I, class T>
 using tuple_element_t = typename tuple_element<I, T>::type;
@@ -108,11 +104,9 @@ struct tuple_size<std::pair<T, U>> : std::integral_constant<std::size_t, 2> {};
 template <class T, std::size_t N>
 struct tuple_size<std::array<T, N>> : std::integral_constant<std::size_t, N> {};
 
-#if defined(CEXA_HAS_CXX20)
 template <class I, class S, std::ranges::subrange_kind K>
 struct tuple_size<std::ranges::subrange<I, S, K>>
     : std::integral_constant<std::size_t, 2> {};
-#endif
 
 template <class T>
 inline constexpr std::size_t tuple_size_v = tuple_size<T>::value;

--- a/tuple/include/impl/helper.hpp
+++ b/tuple/include/impl/helper.hpp
@@ -4,7 +4,7 @@
 
 #include <array>
 #include <cstddef>
-#include <type_traits>  // integral_constant
+#include <type_traits>
 #include <ranges>
 
 #include "tuple_fwd.hpp"

--- a/tuple/include/impl/helper.hpp
+++ b/tuple/include/impl/helper.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 #pragma once
 

--- a/tuple/include/impl/ignore.hpp
+++ b/tuple/include/impl/ignore.hpp
@@ -2,22 +2,12 @@
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 #pragma once
 
-#include "macros.hpp"
 #include <Kokkos_Macros.hpp>
 
 namespace cexa {
 namespace impl {
-// FIXME: address this
-// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 struct ignore_t {
-  KOKKOS_DEFAULTED_FUNCTION constexpr ignore_t() = default;
-  KOKKOS_DEFAULTED_FUNCTION
-#if defined(CEXA_HAS_CXX20)
-  constexpr
-#endif
-      ~ignore_t() = default;
-
-  template <typename T>
+  template <class T>
   KOKKOS_INLINE_FUNCTION constexpr const ignore_t& operator=(
       const T&) const noexcept {
     return *this;

--- a/tuple/include/impl/ignore.hpp
+++ b/tuple/include/impl/ignore.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 #pragma once
 

--- a/tuple/include/impl/macros.hpp
+++ b/tuple/include/impl/macros.hpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 #pragma once
 
+#include <Kokkos_Macros.hpp>
+
 #if defined(_MSVC_LANG)
 #define CEXA_STD_VERSION _MSVC_LANG
 #else
@@ -13,4 +15,9 @@
 #endif
 #if CEXA_STD_VERSION >= 202302L
 #define CEXA_HAS_CXX23
+#endif
+
+// FIXME: As of cuda 13, support for operator<=> in device code is still brittle
+#if !defined(KOKKOS_COMPILER_NVCC)
+#define CEXA_TUPLE_IMPL_USE_SPACESHIP_OPERATOR
 #endif

--- a/tuple/include/impl/macros.hpp
+++ b/tuple/include/impl/macros.hpp
@@ -10,10 +10,9 @@
 #define CEXA_STD_VERSION __cplusplus
 #endif
 
-#if CEXA_STD_VERSION >= 202002L
-#define CEXA_HAS_CXX20
-#endif
-#if CEXA_STD_VERSION >= 202302L
+// GCC 13 defines __cplusplus to 202100L when in c++23
+#if (defined(KOKKOS_COMPILER_GNU) && CEXA_STD_VERSION >= 202100L) || \
+    CEXA_STD_VERSION >= 202302L
 #define CEXA_HAS_CXX23
 #endif
 

--- a/tuple/include/impl/macros.hpp
+++ b/tuple/include/impl/macros.hpp
@@ -16,6 +16,12 @@
 #define CEXA_HAS_CXX23
 #endif
 
+#if defined(KOKKOS_COMPILER_NVCC)
+#define CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE _Pragma("nv_exec_check_disable")
+#else
+#define CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
+#endif
+
 // FIXME: As of cuda 13, support for operator<=> in device code is still brittle
 #if !defined(KOKKOS_COMPILER_NVCC)
 #define CEXA_TUPLE_IMPL_USE_SPACESHIP_OPERATOR

--- a/tuple/include/impl/macros.hpp
+++ b/tuple/include/impl/macros.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 #pragma once
 

--- a/tuple/include/impl/traits.hpp
+++ b/tuple/include/impl/traits.hpp
@@ -4,48 +4,11 @@
 
 #include <array>
 #include <type_traits>
-#include <functional>
-#if defined(CEXA_HAS_CXX20)
 #include <ranges>
-#endif
 
 #include "tuple_fwd.hpp"
 
 namespace cexa::impl {
-#if defined(CEXA_HAS_CXX20)
-template <class T>
-using remove_cvref = std::remove_cvref<T>;
-#else
-template <class T>
-struct remove_cvref {
-  using type = std::remove_cv_t<std::remove_reference_t<T>>;
-};
-#endif
-template <class T>
-using remove_cvref_t = typename remove_cvref<T>::type;
-
-#if defined(CEXA_HAS_CXX20)
-template <class T>
-using unwrap_ref_decay = std::unwrap_ref_decay<T>;
-#else
-template <class T>
-struct unwrap_reference {
-  using type = T;
-};
-
-template <class T>
-struct unwrap_reference<std::reference_wrapper<T>> {
-  using type = T&;
-};
-
-template <class T>
-struct unwrap_ref_decay {
-  using type = typename unwrap_reference<std::decay_t<T>>::type;
-};
-#endif
-template <class T>
-using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
-
 // NOTE: Since const T& t = {} is not an expression, we check that a member of
 // type T can be initialized with empty braces when calling a constructor.
 template <class U, class = void>
@@ -96,13 +59,11 @@ struct is_tuple_like_impl<std::tuple<Types...>> : std::true_type {};
 template <typename... Types>
 struct is_tuple_like_impl<cexa::tuple<Types...>> : std::true_type {};
 
-#if defined(CEXA_HAS_CXX20)
 template <class I, class S, std::ranges::subrange_kind K>
 struct is_tuple_like_impl<std::ranges::subrange<I, S, K>> : std::true_type {};
-#endif
 
 template <typename T>
-struct is_tuple_like : is_tuple_like_impl<impl::remove_cvref_t<T>> {};
+struct is_tuple_like : is_tuple_like_impl<std::remove_cvref_t<T>> {};
 
 template <typename T>
 inline constexpr bool is_tuple_like_v = is_tuple_like<T>::value;
@@ -121,10 +82,8 @@ inline constexpr bool is_tuple_v = is_tuple<T>::value;
 template <class T>
 struct is_subrange : std::false_type {};
 
-#if defined(CEXA_HAS_CXX20)
 template <class I, class S, std::ranges::subrange_kind K>
 struct is_subrange<std::ranges::subrange<I, S, K>> : std::true_type {};
-#endif
 
 template <class T>
 inline constexpr bool is_subrange_v = is_subrange<T>::value;
@@ -133,7 +92,7 @@ inline constexpr bool is_subrange_v = is_subrange<T>::value;
 template <class T, class U>
 struct is_different_from {
   static constexpr bool value =
-      !std::is_same_v<remove_cvref_t<T>, remove_cvref_t<U>>;
+      !std::is_same_v<std::remove_cvref_t<T>, std::remove_cvref_t<U>>;
 };
 
 template <class T, class U>
@@ -146,37 +105,38 @@ struct reference_constructs_from_temporary : std::false_type {};
 template <class T, class U>
 struct reference_constructs_from_temporary<const T&, U>
     : std::integral_constant<
-          bool, (std::is_same_v<remove_cvref_t<T>, remove_cvref_t<U>> &&
-                 !std::is_reference_v<U>) ||
-                    (std::conjunction_v<
-                        std::negation<
-                            std::is_same<remove_cvref_t<T>, remove_cvref_t<U>>>,
-                        std::is_convertible<
-                            std::conditional_t<std::is_scalar_v<U> ||
-                                                   std::is_void_v<U>,
-                                               std::remove_cv_t<U>, U>,
-                            T>>)> {};
+          bool,
+          (std::is_same_v<std::remove_cvref_t<T>, std::remove_cvref_t<U>> &&
+           !std::is_reference_v<U>) ||
+              (std::conjunction_v<
+                  std::negation<std::is_same<std::remove_cvref_t<T>,
+                                             std::remove_cvref_t<U>>>,
+                  std::is_convertible<
+                      std::conditional_t<std::is_scalar_v<U> ||
+                                             std::is_void_v<U>,
+                                         std::remove_cv_t<U>, U>,
+                      T>>)> {};
 
 template <class T, class U>
 struct reference_constructs_from_temporary<T&&, U>
     : std::integral_constant<
-          bool, (std::is_same_v<remove_cvref_t<T>, remove_cvref_t<U>> &&
-                 !std::is_reference_v<U>) ||
-                    (std::conjunction_v<
-                        std::negation<
-                            std::is_same<remove_cvref_t<T>, remove_cvref_t<U>>>,
-                        std::is_convertible<
-                            std::conditional_t<std::is_scalar_v<U> ||
-                                                   std::is_void_v<U>,
-                                               std::remove_cv_t<U>, U>,
-                            T>>)> {};
+          bool,
+          (std::is_same_v<std::remove_cvref_t<T>, std::remove_cvref_t<U>> &&
+           !std::is_reference_v<U>) ||
+              (std::conjunction_v<
+                  std::negation<std::is_same<std::remove_cvref_t<T>,
+                                             std::remove_cvref_t<U>>>,
+                  std::is_convertible<
+                      std::conditional_t<std::is_scalar_v<U> ||
+                                             std::is_void_v<U>,
+                                         std::remove_cv_t<U>, U>,
+                      T>>)> {};
 
 template <class T, class U>
 constexpr inline bool reference_constructs_from_temporary_v =
     reference_constructs_from_temporary<T, U>::value;
 
 // common_reference helper
-#if defined(CEXA_HAS_CXX20)
 template <class TTuple, class UTuple, template <class> class TQual,
           template <class> class UQual, class IndexSeq>
 struct common_reference_helper;
@@ -189,7 +149,6 @@ struct common_reference_helper<TTuple, UTuple, TQual, UQual,
       std::common_reference_t<TQual<std::tuple_element_t<Ints, TTuple>>,
                               UQual<std::tuple_element_t<Ints, UTuple>>>...>;
 };
-#endif
 
 // common_type helper
 template <class TTuple, class UTuple, class IndexSeq>
@@ -205,7 +164,6 @@ struct common_type_helper<TTuple, UTuple, std::index_sequence<Ints...>> {
 }  // namespace cexa::impl
 
 // tuple.common.ref
-#if defined(CEXA_HAS_CXX20)
 // NOTE: specializations of std::basic_common_reference are allowed if T1 and/or
 // T2 is a user defined type and std::decay is and identity transformation for
 // T1 and T2
@@ -240,7 +198,6 @@ struct std::basic_common_reference<TTuple, cexa::tuple<UTypes...>, TQual,
       decltype(std::index_sequence_for<UTypes...>{})>::type;
 };
 // NOLINTEND(cert-dcl58-cpp)
-#endif
 
 // NOTE: specializations of std::common_type are allowed if T1 and/or T2 is a
 // user defined type and std::decay is and identity transformation for T1 and T2

--- a/tuple/include/impl/traits.hpp
+++ b/tuple/include/impl/traits.hpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include <ranges>
 
+#include "macros.hpp"
 #include "tuple_fwd.hpp"
 
 namespace cexa::impl {
@@ -99,6 +100,10 @@ template <class T, class U>
 inline constexpr bool is_different_from_v = is_different_from<T, U>::value;
 
 // reference_constructs_from_temporary
+#ifdef CEXA_HAS_CXX23
+using std::reference_constructs_from_temporary;
+using std::reference_constructs_from_temporary_v;
+#else
 template <class T, class U>
 struct reference_constructs_from_temporary : std::false_type {};
 
@@ -135,6 +140,7 @@ struct reference_constructs_from_temporary<T&&, U>
 template <class T, class U>
 constexpr inline bool reference_constructs_from_temporary_v =
     reference_constructs_from_temporary<T, U>::value;
+#endif
 
 // common_reference helper
 template <class TTuple, class UTuple, template <class> class TQual,

--- a/tuple/include/impl/traits.hpp
+++ b/tuple/include/impl/traits.hpp
@@ -13,25 +13,25 @@ namespace cexa::impl {
 // NOTE: Since const T& t = {} is not an expression, we check that a member of
 // type T can be initialized with empty braces when calling a constructor.
 template <class U, class = void>
-struct empty_copy_list_initializable_helper : std::false_type {};
+struct is_empty_copy_list_initializable_helper : std::false_type {};
 template <class U>
-struct empty_copy_list_initializable_helper<U, std::void_t<decltype(U({}))>>
+struct is_empty_copy_list_initializable_helper<U, std::void_t<decltype(U({}))>>
     : std::true_type {};
 
 template <class T>
-struct empty_copy_list_initializable {
+struct is_empty_copy_list_initializable {
   struct helper {
     // NOLINTNEXTLINE(google-explicit-constructor)
     helper(const T&) {}
   };
 
   static constexpr bool value =
-      empty_copy_list_initializable_helper<helper>::value;
+      is_empty_copy_list_initializable_helper<helper>::value;
 };
 
 template <class T>
-inline constexpr bool empty_copy_list_initializable_v =
-    empty_copy_list_initializable<T>::value;
+inline constexpr bool is_empty_copy_list_initializable_v =
+    is_empty_copy_list_initializable<T>::value;
 
 // is_tuple_like
 // tells if a type is tuple-like, tuple-like types include array, pair,

--- a/tuple/include/impl/traits.hpp
+++ b/tuple/include/impl/traits.hpp
@@ -171,7 +171,7 @@ struct common_type_helper<TTuple, UTuple, std::index_sequence<Ints...>> {
 
 // tuple.common.ref
 // NOTE: specializations of std::basic_common_reference are allowed if T1 and/or
-// T2 is a user defined type and std::decay is and identity transformation for
+// T2 is a user defined type and std::decay is an identity transformation for
 // T1 and T2
 // NOLINTBEGIN(cert-dcl58-cpp)
 template <class... TTypes, class UTuple, template <class> class TQual,

--- a/tuple/include/impl/traits.hpp
+++ b/tuple/include/impl/traits.hpp
@@ -100,10 +100,6 @@ template <class T, class U>
 inline constexpr bool is_different_from_v = is_different_from<T, U>::value;
 
 // reference_constructs_from_temporary
-#ifdef CEXA_HAS_CXX23
-using std::reference_constructs_from_temporary;
-using std::reference_constructs_from_temporary_v;
-#else
 template <class T, class U>
 struct reference_constructs_from_temporary : std::false_type {};
 
@@ -140,7 +136,6 @@ struct reference_constructs_from_temporary<T&&, U>
 template <class T, class U>
 constexpr inline bool reference_constructs_from_temporary_v =
     reference_constructs_from_temporary<T, U>::value;
-#endif
 
 // common_reference helper
 template <class TTuple, class UTuple, template <class> class TQual,
@@ -173,7 +168,7 @@ struct common_type_helper<TTuple, UTuple, std::index_sequence<Ints...>> {
 // NOTE: specializations of std::basic_common_reference are allowed if T1 and/or
 // T2 is a user defined type and std::decay is an identity transformation for
 // T1 and T2
-// NOLINTBEGIN(cert-dcl58-cpp)
+// NOLINTBEGIN(cert-dcl58-cpp,bugprone-std-namespace-modification)
 template <class... TTypes, class UTuple, template <class> class TQual,
           template <class> class UQual>
 struct std::basic_common_reference<cexa::tuple<TTypes...>, UTuple, TQual,
@@ -203,11 +198,11 @@ struct std::basic_common_reference<TTuple, cexa::tuple<UTypes...>, TQual,
       TTuple, cexa::tuple<UTypes...>, TQual, UQual,
       decltype(std::index_sequence_for<UTypes...>{})>::type;
 };
-// NOLINTEND(cert-dcl58-cpp)
+// NOLINTEND(cert-dcl58-cpp,bugprone-std-namespace-modification)
 
 // NOTE: specializations of std::common_type are allowed if T1 and/or T2 is a
 // user defined type and std::decay is and identity transformation for T1 and T2
-// NOLINTBEGIN(cert-dcl58-cpp)
+// NOLINTBEGIN(cert-dcl58-cpp,bugprone-std-namespace-modification)
 template <class... TTypes, class UTuple>
 struct std::common_type<cexa::tuple<TTypes...>, UTuple> {
   static_assert(std::is_same_v<cexa::tuple<TTypes...>,
@@ -216,7 +211,7 @@ struct std::common_type<cexa::tuple<TTypes...>, UTuple> {
   static_assert(sizeof...(TTypes) ==
                 std::tuple_size_v<std::remove_reference_t<UTuple>>);
 
-  using type = typename cexa::impl::common_type_helper<
+  using type = cexa::impl::common_type_helper<
       cexa::tuple<TTypes...>, UTuple,
       decltype(std::index_sequence_for<TTypes...>{})>::type;
 };
@@ -229,8 +224,8 @@ struct std::common_type<TTuple, cexa::tuple<UTypes...>> {
   static_assert(std::tuple_size_v<std::remove_reference_t<TTuple>> ==
                 sizeof...(UTypes));
 
-  using type = typename cexa::impl::common_type_helper<
+  using type = cexa::impl::common_type_helper<
       TTuple, cexa::tuple<UTypes...>,
       decltype(std::index_sequence_for<UTypes...>{})>::type;
 };
-// NOLINTEND(cert-dcl58-cpp)
+// NOLINTEND(cert-dcl58-cpp,bugprone-std-namespace-modification)

--- a/tuple/include/impl/traits.hpp
+++ b/tuple/include/impl/traits.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 #pragma once
 

--- a/tuple/include/impl/tuple.hpp
+++ b/tuple/include/impl/tuple.hpp
@@ -539,18 +539,6 @@ concept pair_constructible =
     !impl::reference_constructs_from_temporary_v<
         tuple_element_t<1, std::remove_cvref_t<Tuple>>,
         decltype(std::get<1>(FWD((std::declval<UPair>()))))>;
-
-template <class Tuple, class UTuple>
-concept tuple_like_constructible =
-    impl::is_tuple_like_v<UTuple> &&
-    tuple_size_v<Tuple> == tuple_size_v<std::remove_reference_t<UTuple>> &&
-    impl::all_types_constructible_v<Tuple, UTuple&&> &&
-    !impl::is_tuple_v<std::remove_cvref_t<UTuple>> &&
-    !impl::is_subrange_v<std::remove_cvref_t<UTuple>> &&
-    !impl::any_types_reference_constructs_from_temporary_v<Tuple, UTuple> &&
-    (tuple_size_v<Tuple> != 1 ||
-     !(std::convertible_to<UTuple, tuple_element_t<0, Tuple>> ||
-       std::constructible_from<tuple_element_t<0, Tuple>, UTuple>));
 }  // namespace impl
 
 template <typename... Types>
@@ -724,13 +712,32 @@ class tuple {
       : m_values(std::move(u.first), std::move(u.second)) {}
 #endif
 
-  template <class UTuple>
-    requires impl::tuple_like_constructible<tuple, UTuple>
+  // Using a concept for this leads to compile failures with older clang
+  // versions (fails with clang 16)
+  // NOLINTBEGIN(modernize-use-constraints)
+  template <
+      class UTuple,
+      class = std::enable_if_t<std::conjunction_v<
+          impl::is_tuple_like<UTuple>,
+          std::bool_constant<
+              sizeof...(Types) ==
+              tuple_size<std::remove_reference_t<UTuple>>::value>,
+          impl::all_types_constructible<tuple, UTuple&&>,
+          std::negation<impl::is_tuple<std::remove_cvref_t<UTuple>>>,
+          std::negation<impl::is_subrange<std::remove_cvref_t<UTuple>>>,
+          std::negation<impl::any_types_reference_constructs_from_temporary<
+              tuple, UTuple>>,
+          std::disjunction<
+              std::bool_constant<sizeof...(Types) != 1>,
+              std::negation<std::disjunction<
+                  std::is_convertible<UTuple, tuple_element_t<0, tuple>>,
+                  std::is_constructible<tuple_element_t<0, tuple>, UTuple>>>>>>>
   constexpr explicit(
       (!impl::all_types_convertible_v<UTuple&&, tuple<Types...>>))
       tuple(UTuple&& u)
       : tuple(tuple_like_tag{}, FWD(u),
               std::make_index_sequence<sizeof...(Types)>{}) {}
+  // NOLINTEND(modernize-use-constraints)
 
   KOKKOS_DEFAULTED_FUNCTION
   constexpr ~tuple() = default;

--- a/tuple/include/impl/tuple.hpp
+++ b/tuple/include/impl/tuple.hpp
@@ -129,7 +129,7 @@ struct store<> {
   KOKKOS_DEFAULTED_FUNCTION constexpr store(store&&)      = default;
 #if defined(CEXA_HAS_CXX23)
   KOKKOS_DEFAULTED_FUNCTION constexpr store(store&) noexcept = default;
-  KOKKOS_INLINE_FUNCTION constexpr store(const store&&) noexcept {};
+  KOKKOS_INLINE_FUNCTION constexpr store(const store&&) noexcept {}
 #endif
   KOKKOS_DEFAULTED_FUNCTION constexpr ~store() = default;
 
@@ -443,24 +443,24 @@ class tuple<> {
  public:
   KOKKOS_DEFAULTED_FUNCTION constexpr tuple() noexcept = default;
 
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple(const tuple& u) noexcept = default;
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple(tuple&& u) noexcept      = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple(const tuple&) noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple(tuple&&) noexcept      = default;
 
   KOKKOS_DEFAULTED_FUNCTION constexpr ~tuple() = default;
 
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(
-      const tuple& u) noexcept = default;
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(tuple&& u) noexcept =
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(const tuple&) noexcept =
+      default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(tuple&&) noexcept =
       default;
 #if defined(CEXA_HAS_CXX23)
   // We don't care about self assignment since this is an empty class
   // NOLINTNEXTLINE(cert-oop54-cpp)
   KOKKOS_INLINE_FUNCTION constexpr const tuple& operator=(
-      const tuple& u) const noexcept {
+      const tuple&) const noexcept {
     return *this;
   }
   KOKKOS_INLINE_FUNCTION constexpr const tuple& operator=(
-      tuple&& u) const noexcept {
+      tuple&&) const noexcept {
     return *this;
   }
 #endif

--- a/tuple/include/impl/tuple.hpp
+++ b/tuple/include/impl/tuple.hpp
@@ -198,12 +198,16 @@ struct store<T, Types...> {
   CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   KOKKOS_DEFAULTED_FUNCTION constexpr ~store() = default;
 
+  // FIXME: using requires here leads to compile errors with old nvcc versions
+  // (tested with 12.2)
+  // NOLINTBEGIN(modernize-use-constraints)
   CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
-  template <class U, class... UTypes>
-    requires(sizeof...(UTypes) == sizeof...(Types) &&
-             !(std::is_same_v<U, T> &&
-               (std::is_same_v<UTypes, Types> && ...)) &&
-             std::is_assignable_v<T&, const U&>)
+  template <
+      class U, class... UTypes,
+      class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
+                               !(std::is_same_v<U, T> &&
+                                 (std::is_same_v<UTypes, Types> && ...)) &&
+                               std::is_assignable_v<T&, const U&>>>
   KOKKOS_INLINE_FUNCTION constexpr store& operator=(
       const store<U, UTypes...>& other) {
     value = other.value;
@@ -212,17 +216,19 @@ struct store<T, Types...> {
   }
 
   CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
-  template <class U, class... UTypes>
-    requires(sizeof...(UTypes) == sizeof...(Types) &&
-             !(std::is_same_v<U, T> &&
-               (std::is_same_v<UTypes, Types> && ...)) &&
-             std::is_assignable_v<T&, U &&>)
+  template <
+      class U, class... UTypes,
+      class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
+                               !(std::is_same_v<U, T> &&
+                                 (std::is_same_v<UTypes, Types> && ...)) &&
+                               std::is_assignable_v<T&, U&&>>>
   KOKKOS_INLINE_FUNCTION constexpr store& operator=(
       store<U, UTypes...>&& other) {
     value = FWD(other.value);
     rest  = std::move(other.rest);
     return *this;
   }
+  // NOLINTEND(modernize-use-constraints)
 
   CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   // FIXME: defaulting this operator leads to compile errors where the
@@ -771,9 +777,14 @@ class tuple {
   }
 #endif
 
-  template <class... UTypes>
-    requires(sizeof...(Types) == sizeof...(UTypes)) &&
-            std::conjunction_v<std::is_assignable<Types&, const UTypes&>...>
+  // FIXME: using requires here leads to compile errors with old nvcc versions
+  // (tested with 12.2)
+  // NOLINTBEGIN(modernize-use-constraints)
+  template <
+      class... UTypes,
+      class = std::enable_if_t<
+          sizeof...(Types) == sizeof...(UTypes) &&
+          std::conjunction_v<std::is_assignable<Types&, const UTypes&>...>>>
   KOKKOS_INLINE_FUNCTION constexpr tuple&
   operator=(const tuple<UTypes...>& other) noexcept(
       (std::is_nothrow_assignable_v<Types&, const UTypes&> && ...)) {
@@ -781,15 +792,17 @@ class tuple {
     return *this;
   }
 
-  template <class... UTypes>
-    requires(sizeof...(Types) == sizeof...(UTypes)) &&
-            std::conjunction_v<std::is_assignable<Types&, UTypes>...>
+  template <class... UTypes,
+            class = std::enable_if_t<
+                sizeof...(Types) == sizeof...(UTypes) &&
+                std::conjunction_v<std::is_assignable<Types&, UTypes>...>>>
   KOKKOS_INLINE_FUNCTION constexpr tuple&
   operator=(tuple<UTypes...>&& other) noexcept(
       (std::is_nothrow_assignable_v<Types&, UTypes> && ...)) {
     m_values = std::move(other.m_values);
     return *this;
   }
+  // NOLINTEND(modernize-use-constraints)
 
 #if defined(CEXA_HAS_CXX23)
   template <class... UTypes>

--- a/tuple/include/impl/tuple.hpp
+++ b/tuple/include/impl/tuple.hpp
@@ -554,12 +554,13 @@ concept tuple_like_constructible =
 }  // namespace impl
 
 template <typename... Types>
+// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
 class tuple {
  private:
   template <typename... Ts>
-  using T0 = typename impl::nth_type<0, Ts...>::type;
+  using T0 = impl::nth_type<0, Ts...>::type;
   template <typename... Ts>
-  using T1 = typename impl::nth_type<sizeof...(Ts) == 1 ? 0 : 1, Ts...>::type;
+  using T1 = impl::nth_type<sizeof...(Ts) == 1 ? 0 : 1, Ts...>::type;
 
   struct converting_tag {};
   struct tuple_like_tag {};
@@ -569,6 +570,7 @@ class tuple {
 
   impl::store<Types...> m_values;
 
+  // NOLINTBEGIN(bugprone-use-after-move,hicpp-invalid-access-moved)
   template <class UTuple, std::size_t... Ints>
   KOKKOS_INLINE_FUNCTION constexpr tuple(converting_tag, UTuple&& u,
                                          std::index_sequence<Ints...>)
@@ -577,6 +579,7 @@ class tuple {
   template <class UTuple, std::size_t... Ints>
   constexpr tuple(tuple_like_tag, UTuple&& u, std::index_sequence<Ints...>)
       : m_values(std::get<Ints>(FWD(u))...) {}
+  // NOLINTEND(bugprone-use-after-move,hicpp-invalid-access-moved)
 
  public:
   // tuple.cnstr
@@ -909,38 +912,42 @@ class tuple {
   }
 #endif
 
+  // Using requires here leads to ambiguous calls to get with clang
+  // NOLINTBEGIN(modernize-use-constraints)
   template <std::size_t I, class... Ts>
-    requires(I < sizeof...(Ts))
-  KOKKOS_INLINE_FUNCTION friend constexpr tuple_element_t<I, tuple<Ts...>>& get(
-      tuple<Ts...>& t) noexcept;
+  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
+      (I < sizeof...(Ts)), typename tuple_element<I, tuple<Ts...>>::type&>
+  get(tuple<Ts...>& t) noexcept;
   template <std::size_t I, class... Ts>
-    requires(I < sizeof...(Ts))
-  KOKKOS_INLINE_FUNCTION friend constexpr tuple_element_t<I, tuple<Ts...>>&&
+  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
+      (I < sizeof...(Ts)), typename tuple_element<I, tuple<Ts...>>::type&&>
   get(tuple<Ts...>&& t) noexcept;
   template <std::size_t I, class... Ts>
-    requires(I < sizeof...(Ts))
-  KOKKOS_INLINE_FUNCTION friend constexpr const tuple_element_t<I,
-                                                                tuple<Ts...>>&
+  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
+      (I < sizeof...(Ts)), const typename tuple_element<I, tuple<Ts...>>::type&>
   get(const tuple<Ts...>& t) noexcept;
   template <std::size_t I, class... Ts>
-    requires(I < sizeof...(Ts))
-  KOKKOS_INLINE_FUNCTION friend constexpr const tuple_element_t<I,
-                                                                tuple<Ts...>>&&
+  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
+      (I < sizeof...(Ts)),
+      const typename tuple_element<I, tuple<Ts...>>::type&&>
   get(const tuple<Ts...>&& t) noexcept;
   template <class T, class... Ts>
-    requires(std::is_same_v<T, Ts> || ...)
-  KOKKOS_INLINE_FUNCTION friend constexpr T& get(tuple<Ts...>& t) noexcept;
+  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
+      (std::is_same_v<T, Ts> || ...), T&>
+  get(tuple<Ts...>& t) noexcept;
   template <class T, class... Ts>
-    requires(std::is_same_v<T, Ts> || ...)
-  KOKKOS_INLINE_FUNCTION friend constexpr T&& get(tuple<Ts...>&& t) noexcept;
+  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
+      (std::is_same_v<T, Ts> || ...), T&&>
+  get(tuple<Ts...>&& t) noexcept;
   template <class T, class... Ts>
-    requires(std::is_same_v<T, Ts> || ...)
-  KOKKOS_INLINE_FUNCTION friend constexpr const T& get(
-      const tuple<Ts...>& t) noexcept;
+  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
+      (std::is_same_v<T, Ts> || ...), const T&>
+  get(const tuple<Ts...>& t) noexcept;
   template <class T, class... Ts>
-    requires(std::is_same_v<T, Ts> || ...)
-  KOKKOS_INLINE_FUNCTION friend constexpr const T&& get(
-      const tuple<Ts...>&& t) noexcept;
+  KOKKOS_INLINE_FUNCTION friend constexpr const std::enable_if_t<
+      (std::is_same_v<T, Ts> || ...), const T&&>
+  get(const tuple<Ts...>&& t) noexcept;
+  // NOLINTEND(modernize-use-constraints)
 
   // tuple.rel
 #if defined(CEXA_TUPLE_IMPL_USE_SPACESHIP_OPERATOR)
@@ -1004,15 +1011,16 @@ template <class T1, class T2>
 tuple(std::pair<T1, T2>) -> tuple<T1, T2>;
 
 // tuple.elem
+// NOLINTBEGIN(modernize-use-constraints)
 template <std::size_t I, class... Types>
-  requires(I < sizeof...(Types))
-KOKKOS_INLINE_FUNCTION constexpr tuple_element_t<I, tuple<Types...>>& get(
-    tuple<Types...>& t) noexcept {
+KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+    (I < sizeof...(Types)), typename tuple_element<I, tuple<Types...>>::type&>
+get(tuple<Types...>& t) noexcept {
   return t.m_values.template get_value<I>();
 }
 template <std::size_t I, class... Types>
-  requires(I < sizeof...(Types))
-KOKKOS_INLINE_FUNCTION constexpr tuple_element_t<I, tuple<Types...>>&&
+KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+    (I < sizeof...(Types)), typename tuple_element<I, tuple<Types...>>::type&&>
 // NOTE: this doesn't work with std::move
 // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
 get(tuple<Types...>&& t) noexcept {
@@ -1020,43 +1028,47 @@ get(tuple<Types...>&& t) noexcept {
       t.m_values.template get_value<I>());
 }
 template <std::size_t I, class... Types>
-  requires(I < sizeof...(Types))
-KOKKOS_INLINE_FUNCTION constexpr const tuple_element_t<I, tuple<Types...>>& get(
-    const tuple<Types...>& t) noexcept {
+KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+    (I < sizeof...(Types)),
+    const typename tuple_element<I, tuple<Types...>>::type&>
+get(const tuple<Types...>& t) noexcept {
   return t.m_values.template get_value<I>();
 }
 template <std::size_t I, class... Types>
-  requires(I < sizeof...(Types))
-KOKKOS_INLINE_FUNCTION constexpr const tuple_element_t<I, tuple<Types...>>&&
+KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+    (I < sizeof...(Types)),
+    const typename tuple_element<I, tuple<Types...>>::type&&>
 get(const tuple<Types...>&& t) noexcept {
   return static_cast<const tuple_element_t<I, tuple<Types...>>&&>(
       t.m_values.template get_value<I>());
 }
 template <class T, class... Types>
-  requires(std::is_same_v<T, Types> || ...)
-KOKKOS_INLINE_FUNCTION constexpr T& get(tuple<Types...>& t) noexcept {
+KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+    (std::is_same_v<T, Types> || ...), T&>
+get(tuple<Types...>& t) noexcept {
   return t.m_values.template get_value<T>();
 }
 template <class T, class... Types>
-  requires(std::is_same_v<T, Types> || ...)
-KOKKOS_INLINE_FUNCTION constexpr T&&
+KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+    (std::is_same_v<T, Types> || ...), T&&>
 // NOTE: this doesn't work with std::move
 // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
 get(tuple<Types...>&& t) noexcept {
   return static_cast<T&&>(t.m_values.template get_value<T>());
 }
 template <class T, class... Types>
-  requires(std::is_same_v<T, Types> || ...)
-KOKKOS_INLINE_FUNCTION constexpr const T& get(
-    const tuple<Types...>& t) noexcept {
+KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+    (std::is_same_v<T, Types> || ...), const T&>
+get(const tuple<Types...>& t) noexcept {
   return t.m_values.template get_value<T>();
 }
 template <class T, class... Types>
-  requires(std::is_same_v<T, Types> || ...)
-KOKKOS_INLINE_FUNCTION constexpr const T&& get(
-    const tuple<Types...>&& t) noexcept {
+KOKKOS_INLINE_FUNCTION constexpr const std::enable_if_t<
+    (std::is_same_v<T, Types> || ...), const T&&>
+get(const tuple<Types...>&& t) noexcept {
   return static_cast<const T&&>(t.m_values.template get_value<T>());
 }
+// NOLINTEND(modernize-use-constraints)
 
 template <class... Types>
   requires(std::is_swappable_v<Types> && ...)

--- a/tuple/include/impl/tuple.hpp
+++ b/tuple/include/impl/tuple.hpp
@@ -7,63 +7,16 @@
 #include <memory>
 #include <type_traits>
 #include <utility>
+#if defined(CEXA_TUPLE_IMPL_USE_SPACESHIP_OPERATOR)
+#include <compare>
+#endif
 
 #include "macros.hpp"
 #include "traits.hpp"
 #include "helper.hpp"
 #include "tuple_fwd.hpp"
 
-#if defined(CEXA_HAS_CXX20)
-#include <compare>
-#endif
-
 namespace cexa {
-
-// Pre-declarations of get, as C++17 doesn't allow the function to be used
-// before its declaration.
-#if !defined(CEXA_HAS_CXX20)
-template <std::size_t I, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (I < sizeof...(Types)), typename tuple_element<I, tuple<Types...>>::type&>
-get(tuple<Types...>& t) noexcept;
-
-template <std::size_t I, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (I < sizeof...(Types)), typename tuple_element<I, tuple<Types...>>::type&&>
-get(tuple<Types...>&& t) noexcept;
-
-template <std::size_t I, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (I < sizeof...(Types)),
-    const typename tuple_element<I, tuple<Types...>>::type&>
-get(const tuple<Types...>& t) noexcept;
-
-template <std::size_t I, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (I < sizeof...(Types)),
-    const typename tuple_element<I, tuple<Types...>>::type&&>
-get(const tuple<Types...>&& t) noexcept;
-
-template <class T, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (std::is_same_v<T, Types> || ...), T&>
-get(tuple<Types...>& t) noexcept;
-
-template <class T, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (std::is_same_v<T, Types> || ...), T&&>
-get(tuple<Types...>&& t) noexcept;
-
-template <class T, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (std::is_same_v<T, Types> || ...), const T&>
-get(const tuple<Types...>& t) noexcept;
-
-template <class T, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr const std::enable_if_t<
-    (std::is_same_v<T, Types> || ...), const T&&>
-get(const tuple<Types...>&& t) noexcept;
-#endif
 
 namespace impl {
 
@@ -157,47 +110,20 @@ template <class Tuple, class UTuple>
 inline constexpr bool any_types_reference_constructs_from_temporary_v =
     any_types_reference_constructs_from_temporary<Tuple, UTuple>::value;
 
-template <bool, bool, bool, bool>
-struct Bools {};
-
-template <class B, typename... Types>
+template <typename... Types>
 struct store;
 
 template <class T>
 struct is_store : std::false_type {};
 
-template <bool a, bool b, bool c, bool d, class... Types>
-struct is_store<store<Bools<a, b, c, d>, Types...>> : std::true_type {};
+template <class... Types>
+struct is_store<store<Types...>> : std::true_type {};
 
 template <class T>
-inline constexpr bool is_store_v = is_store<impl::remove_cvref_t<T>>::value;
-
-template <class... Types>
-struct store_alias;
+inline constexpr bool is_store_v = is_store<std::remove_cvref_t<T>>::value;
 
 template <>
-struct store_alias<> {
-  using type = store<Bools<false, false, false, false>>;
-};
-template <class T, class... Types>
-struct store_alias<T, Types...> {
-  using type = store<
-      Bools<std::is_copy_assignable_v<T>, std::is_copy_assignable_v<const T>,
-            std::is_move_assignable_v<T>, std::is_assignable_v<const T&, T&&>>,
-      T, Types...>;
-};
-
-template <class... Types>
-using store_ = typename store_alias<Types...>::type;
-
-#if defined(CEXA_HAS_CXX20)
-#define CEXA_CONSTEXPR_CXX20 constexpr
-#else
-#define CEXA_CONSTEXPR_CXX20
-#endif
-
-template <>
-struct store<Bools<false, false, false, false>> {
+struct store<> {
   KOKKOS_DEFAULTED_FUNCTION constexpr store()             = default;
   KOKKOS_DEFAULTED_FUNCTION constexpr store(const store&) = default;
   KOKKOS_DEFAULTED_FUNCTION constexpr store(store&&)      = default;
@@ -205,7 +131,7 @@ struct store<Bools<false, false, false, false>> {
   KOKKOS_DEFAULTED_FUNCTION constexpr store(store&) noexcept {}
   KOKKOS_DEFAULTED_FUNCTION constexpr store(const store&&) noexcept {};
 #endif
-  KOKKOS_DEFAULTED_FUNCTION CEXA_CONSTEXPR_CXX20 ~store() = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr ~store() = default;
 
   KOKKOS_DEFAULTED_FUNCTION constexpr store& operator=(const store&) = default;
   KOKKOS_DEFAULTED_FUNCTION constexpr store& operator=(store&&)      = default;
@@ -226,749 +152,314 @@ struct store<Bools<false, false, false, false>> {
   KOKKOS_INLINE_FUNCTION constexpr void swap(const store&) const noexcept {}
 #endif
 
-#if defined(CEXA_HAS_CXX20)
+#if defined(CEXA_TUPLE_IMPL_USE_SPACESHIP_OPERATOR)
   KOKKOS_DEFAULTED_FUNCTION auto operator<=>(const store&) const = default;
-#endif
-};
-
-#if !defined(CEXA_HAS_CXX20)
-KOKKOS_INLINE_FUNCTION constexpr bool operator==(const store_<>&,
-                                                 const store_<>&) {
-  return true;
-}
-KOKKOS_INLINE_FUNCTION constexpr bool operator<(const store_<>&,
-                                                const store_<>&) {
-  return false;
-}
-#endif
-
-#if defined(CEXA_HAS_CXX20)
-// TODO: check if the non-three way comparable case should always return
-// weak_ordering
-#define STORE_SPACESHIP_COMP                                                  \
-  template <bool b1, bool b2, bool b3, bool b4, class U, class... UTypes>     \
-    requires std::three_way_comparable_with<T, U>                             \
-  KOKKOS_INLINE_FUNCTION constexpr auto operator<=>(                          \
-      const store<Bools<b1, b2, b3, b4>, U, UTypes...>& rhs)                  \
-      const->std::common_comparison_category_t<decltype(value <=> rhs.value), \
-                                               decltype(rest <=> rhs.rest)> { \
-    auto res = value <=> rhs.value;                                           \
-    return res != 0 ? res : rest <=> rhs.rest;                                \
-  }                                                                           \
-  template <bool b1, bool b2, bool b3, bool b4, class U, class... UTypes>     \
-  KOKKOS_INLINE_FUNCTION constexpr std::weak_ordering operator<=>(            \
-      const store<Bools<b1, b2, b3, b4>, U, UTypes...>& rhs) const {          \
-    if (value < rhs.value) {                                                  \
-      return std::weak_ordering::less;                                        \
-    } else if (rhs.value < value) {                                           \
-      return std::weak_ordering::greater;                                     \
-    } else {                                                                  \
-      return static_cast<std::weak_ordering>(rest <=> rhs.rest);              \
-    }                                                                         \
-  }                                                                           \
-  template <bool b1, bool b2, bool b3, bool b4, class U, class... UTypes>     \
-  KOKKOS_INLINE_FUNCTION constexpr bool operator==(                           \
-      const store<Bools<b1, b2, b3, b4>, U, UTypes...>& rhs) const {          \
-    return operator<=>(rhs) == 0;                                             \
-  }
 #else
-#define STORE_SPACESHIP_COMP
-#endif
-
-#if defined(CEXA_HAS_CXX23)
-#define STORE_CXX23_CONST_SWAP                                            \
-  KOKKOS_INLINE_FUNCTION constexpr void swap(const store& rhs)            \
-      const noexcept(std::is_nothrow_swappable_v<const T> &&              \
-                     (std::is_nothrow_swappable_v<const Types> && ...)) { \
-    using std::swap;                                                      \
-    swap(value, rhs.value);                                               \
-    rest.swap(rhs.rest);                                                  \
-  }
-#define STORE_CXX23_CONST_ASSIGN                                              \
-  template <bool b1, bool b2, bool b3, bool b4, class U, class... UTypes,     \
-            class =                                                           \
-                std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&     \
-                                 !(std::is_same_v<U, T> &&                    \
-                                   (std::is_same_v<UTypes, Types> && ...)) && \
-                                 std::is_assignable_v<const T&, const U&>>>   \
-  KOKKOS_INLINE_FUNCTION constexpr const store& operator=(                    \
-      const store<Bools<b1, b2, b3, b4>, U, UTypes...>& other) const {        \
-    value = other.value;                                                      \
-    rest  = other.rest;                                                       \
-    return *this;                                                             \
-  }                                                                           \
-  template <bool b1, bool b2, bool b3, bool b4, class U, class... UTypes,     \
-            class =                                                           \
-                std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&     \
-                                 !(std::is_same_v<U, T> &&                    \
-                                   (std::is_same_v<UTypes, Types> && ...)) && \
-                                 std::is_assignable_v<const T&, U&&>>>        \
-  KOKKOS_INLINE_FUNCTION constexpr const store& operator=(                    \
-      store<Bools<b1, b2, b3, b4>, U, UTypes...>&& other) const {             \
-    value = FWD(other.value);                                                 \
-    rest  = std::move(other.rest);                                            \
-    return *this;                                                             \
-  }
-#else
-#define STORE_CXX23_CONST_SWAP
-#define STORE_CXX23_CONST_ASSIGN
-#endif
-
-#define STORE_COMMON_FUNCS                                                     \
-  T value{};                                                                   \
-  store_<Types...> rest;                                                       \
-                                                                               \
-  KOKKOS_DEFAULTED_FUNCTION constexpr store() = default;                       \
-                                                                               \
-  KOKKOS_DEFAULTED_FUNCTION constexpr store(const store& other) = default;     \
-  template <class Dummy = void,                                                \
-            class       = std::enable_if_t<std::is_same_v<Dummy, void> &&      \
-                                           std::is_move_constructible_v<T>>>   \
-  KOKKOS_INLINE_FUNCTION constexpr explicit store(store&& other)               \
-      : value(FWD(other.value)), rest(FWD(other.rest)) {}                      \
-                                                                               \
-  template <typename U, typename... UTypes,                                    \
-            class = std::enable_if_t<!is_store_v<U> &&                         \
-                                     (!is_store_v<UTypes> && ...)>>            \
-  KOKKOS_INLINE_FUNCTION constexpr store(U&& u, UTypes&&... args)              \
-      : value(FWD(u)), rest(FWD(args)...) {}                                   \
-                                                                               \
-  KOKKOS_DEFAULTED_FUNCTION CEXA_CONSTEXPR_CXX20 ~store() = default;           \
-                                                                               \
-  template <bool b1, bool b2, bool b3, bool b4, class U, class... UTypes,      \
-            class =                                                            \
-                std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&      \
-                                 !(std::is_same_v<U, T> &&                     \
-                                   (std::is_same_v<UTypes, Types> && ...)) &&  \
-                                 std::is_assignable_v<T&, const U&>>>          \
-  KOKKOS_INLINE_FUNCTION constexpr store& operator=(                           \
-      const store<Bools<b1, b2, b3, b4>, U, UTypes...>& other) {               \
-    value = other.value;                                                       \
-    rest  = other.rest;                                                        \
-    return *this;                                                              \
-  }                                                                            \
-  template <bool b1, bool b2, bool b3, bool b4, class U, class... UTypes,      \
-            class =                                                            \
-                std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&      \
-                                 !(std::is_same_v<U, T> &&                     \
-                                   (std::is_same_v<UTypes, Types> && ...)) &&  \
-                                 std::is_assignable_v<T&, U&&>>>               \
-  KOKKOS_INLINE_FUNCTION constexpr store& operator=(                           \
-      store<Bools<b1, b2, b3, b4>, U, UTypes...>&& other) {                    \
-    value = FWD(other.value);                                                  \
-    rest  = std::move(other.rest);                                             \
-    return *this;                                                              \
-  }                                                                            \
-  STORE_CXX23_CONST_ASSIGN                                                     \
-                                                                               \
-  template <std::size_t I>                                                     \
-  KOKKOS_INLINE_FUNCTION constexpr tuple_element_t<I, tuple<T, Types...>>&     \
-  get_value() noexcept {                                                       \
-    if constexpr (I == 0) {                                                    \
-      return value;                                                            \
-    } else {                                                                   \
-      return rest.template get_value<I - 1>();                                 \
-    }                                                                          \
-  }                                                                            \
-                                                                               \
-  template <std::size_t I>                                                     \
-  KOKKOS_INLINE_FUNCTION constexpr const tuple_element_t<I,                    \
-                                                         tuple<T, Types...>>&  \
-  get_value() const noexcept {                                                 \
-    if constexpr (I == 0) {                                                    \
-      return value;                                                            \
-    } else {                                                                   \
-      return rest.template get_value<I - 1>();                                 \
-    }                                                                          \
-  }                                                                            \
-                                                                               \
-  template <class Type>                                                        \
-  KOKKOS_INLINE_FUNCTION constexpr Type& get_value() noexcept {                \
-    if constexpr (std::is_same_v<Type, T>) {                                   \
-      return value;                                                            \
-    } else {                                                                   \
-      return rest.template get_value<Type>();                                  \
-    }                                                                          \
-  }                                                                            \
-                                                                               \
-  template <class Type>                                                        \
-  KOKKOS_INLINE_FUNCTION constexpr const Type& get_value() const noexcept {    \
-    if constexpr (std::is_same_v<Type, T>) {                                   \
-      return value;                                                            \
-    } else {                                                                   \
-      return rest.template get_value<Type>();                                  \
-    }                                                                          \
-  }                                                                            \
-                                                                               \
-  template <class U, class = std::enable_if_t<std::is_assignable_v<            \
-                         T&, decltype(std::forward<U>(std::declval<U&&>()))>>> \
-  KOKKOS_INLINE_FUNCTION constexpr void set_all(U&& u) {                       \
-    value = u;                                                                 \
-  }                                                                            \
-                                                                               \
-  template <class U, class... UTypes,                                          \
-            class = std::enable_if_t<std::is_assignable_v<                     \
-                T&, decltype(std::forward<U>(std::declval<U&&>()))>>>          \
-  KOKKOS_INLINE_FUNCTION constexpr void set_all(U&& head, UTypes&&... tail) {  \
-    value = head;                                                              \
-    rest.set_all(FWD(tail)...);                                                \
-  }                                                                            \
-                                                                               \
-  template <class UTuple>                                                      \
-  inline constexpr void set(UTuple&& u) {                                      \
-    set(FWD(u), std::make_index_sequence<1 + sizeof...(Types)>{});             \
-  }                                                                            \
-                                                                               \
-  template <class UTuple, std::size_t... Ints>                                 \
-  inline constexpr void set(UTuple&& u, std::index_sequence<Ints...>) {        \
-    set_all(get<Ints>(FWD(u))...);                                             \
-  }                                                                            \
-                                                                               \
-  KOKKOS_INLINE_FUNCTION constexpr void swap(store& rhs) noexcept(             \
-      std::is_nothrow_swappable_v<T> &&                                        \
-      (std::is_nothrow_swappable_v<Types> && ...)) {                           \
-    using std::swap;                                                           \
-    swap(value, rhs.value);                                                    \
-    rest.swap(rhs.rest);                                                       \
-  }                                                                            \
-                                                                               \
-  STORE_CXX23_CONST_SWAP                                                       \
-  STORE_SPACESHIP_COMP
-
-#define STORE_COPY_ASSIGN                                  \
-  KOKKOS_INLINE_FUNCTION constexpr store&                  \
-  operator=(const store& other) noexcept(                  \
-      std::is_nothrow_copy_assignable_v<T> &&              \
-      (std::is_nothrow_copy_assignable_v<Types> && ...)) { \
-    value = other.value;                                   \
-    rest  = other.rest;                                    \
-    return *this;                                          \
-  }
-
-// NOLINTBEGIN(bugprone-macro-parentheses)
-#define STORE_MOVE_ASSIGN                                                    \
-  KOKKOS_INLINE_FUNCTION constexpr store& operator=(store&& other) noexcept( \
-      std::is_nothrow_move_assignable_v<T> &&                                \
-      (std::is_nothrow_move_assignable_v<Types> && ...)) {                   \
-    value = std::move(other.value);                                          \
-    rest  = std::move(other.rest);                                           \
-    return *this;                                                            \
-  }
-// NOLINTEND(bugprone-macro-parentheses)
-
-#define DELETED_STORE_COPY_ASSIGN \
-  constexpr store& operator=(const store&) = delete;
-#define DELETED_STORE_MOVE_ASSIGN constexpr store& operator=(store&&) = delete;
-
-#if defined(CEXA_HAS_CXX23)
-#define STORE_CONST_COPY_ASSIGN                                               \
-  KOKKOS_INLINE_FUNCTION constexpr const store& operator=(const store& other) \
-      const {                                                                 \
-    value = other.value;                                                      \
-    rest  = other.rest;                                                       \
-    return *this;                                                             \
-  }
-#define STORE_CONST_MOVE_ASSIGN                                          \
-  KOKKOS_INLINE_FUNCTION constexpr const store& operator=(store&& other) \
-      const noexcept(                                                    \
-          std::is_nothrow_move_assignable_v<const T> &&                  \
-          (std::is_nothrow_move_assignable_v<const Types> && ...)) {     \
-    value = std::move(other.value);                                      \
-    rest  = std::move(other.rest);                                       \
-    return *this;                                                        \
-  }
-#define DELETED_STORE_CONST_COPY_ASSIGN \
-  constexpr const store& operator=(const store&) const = delete;
-#define DELETED_STORE_CONST_MOVE_ASSIGN \
-  constexpr const store& operator=(store&&) const = delete;
-#else
-#define STORE_CONST_MOVE_ASSIGN
-#define STORE_CONST_COPY_ASSIGN
-#define DELETED_STORE_CONST_COPY_ASSIGN
-#define DELETED_STORE_CONST_MOVE_ASSIGN
-#endif
-
-// NOLINTBEGIN(cppcoreguidelines-special-member-functions,
-// google-explicit-constructor) NOTE: move constructor is templated so
-// clang-tidy complains that the structs don't have a move constructor
-template <class T, class... Types>
-struct store<Bools<false, false, false, false>, T, Types...> {
-  STORE_COMMON_FUNCS
-  DELETED_STORE_COPY_ASSIGN
-  DELETED_STORE_CONST_COPY_ASSIGN
-  DELETED_STORE_MOVE_ASSIGN
-  DELETED_STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<false, false, false, true>, T, Types...> {
-  STORE_COMMON_FUNCS
-  DELETED_STORE_COPY_ASSIGN
-  DELETED_STORE_CONST_COPY_ASSIGN
-  DELETED_STORE_MOVE_ASSIGN
-  STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<false, false, true, false>, T, Types...> {
-  STORE_COMMON_FUNCS
-  DELETED_STORE_COPY_ASSIGN
-  DELETED_STORE_CONST_COPY_ASSIGN
-  STORE_MOVE_ASSIGN
-  DELETED_STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<false, false, true, true>, T, Types...> {
-  STORE_COMMON_FUNCS
-  DELETED_STORE_COPY_ASSIGN
-  DELETED_STORE_CONST_COPY_ASSIGN
-  STORE_MOVE_ASSIGN
-  STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<false, true, false, false>, T, Types...> {
-  STORE_COMMON_FUNCS
-  DELETED_STORE_COPY_ASSIGN
-  STORE_CONST_COPY_ASSIGN
-  DELETED_STORE_MOVE_ASSIGN
-  DELETED_STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<false, true, false, true>, T, Types...> {
-  STORE_COMMON_FUNCS
-  DELETED_STORE_COPY_ASSIGN
-  STORE_CONST_COPY_ASSIGN
-  DELETED_STORE_MOVE_ASSIGN
-  STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<false, true, true, false>, T, Types...> {
-  STORE_COMMON_FUNCS
-  DELETED_STORE_COPY_ASSIGN
-  STORE_CONST_COPY_ASSIGN
-  STORE_MOVE_ASSIGN
-  DELETED_STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<false, true, true, true>, T, Types...> {
-  STORE_COMMON_FUNCS
-  DELETED_STORE_COPY_ASSIGN
-  STORE_CONST_COPY_ASSIGN
-  STORE_MOVE_ASSIGN
-  STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<true, false, false, false>, T, Types...> {
-  STORE_COMMON_FUNCS
-  STORE_COPY_ASSIGN
-  DELETED_STORE_CONST_COPY_ASSIGN
-  DELETED_STORE_MOVE_ASSIGN
-  DELETED_STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<true, false, false, true>, T, Types...> {
-  STORE_COMMON_FUNCS
-  STORE_COPY_ASSIGN
-  DELETED_STORE_CONST_COPY_ASSIGN
-  DELETED_STORE_MOVE_ASSIGN
-  STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<true, false, true, false>, T, Types...> {
-  STORE_COMMON_FUNCS
-  STORE_COPY_ASSIGN
-  DELETED_STORE_CONST_COPY_ASSIGN
-  STORE_MOVE_ASSIGN
-  DELETED_STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<true, false, true, true>, T, Types...> {
-  STORE_COMMON_FUNCS
-  STORE_COPY_ASSIGN
-  DELETED_STORE_CONST_COPY_ASSIGN
-  STORE_MOVE_ASSIGN
-  STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<true, true, false, false>, T, Types...> {
-  STORE_COMMON_FUNCS
-  STORE_COPY_ASSIGN
-  STORE_CONST_COPY_ASSIGN
-  DELETED_STORE_MOVE_ASSIGN
-  DELETED_STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<true, true, false, true>, T, Types...> {
-  STORE_COMMON_FUNCS
-  STORE_COPY_ASSIGN
-  STORE_CONST_COPY_ASSIGN
-  DELETED_STORE_MOVE_ASSIGN
-  STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<true, true, true, false>, T, Types...> {
-  STORE_COMMON_FUNCS
-  STORE_COPY_ASSIGN
-  STORE_CONST_COPY_ASSIGN
-  STORE_MOVE_ASSIGN
-  DELETED_STORE_CONST_MOVE_ASSIGN
-};
-
-template <class T, class... Types>
-struct store<Bools<true, true, true, true>, T, Types...> {
-  STORE_COMMON_FUNCS
-  STORE_COPY_ASSIGN
-  STORE_CONST_COPY_ASSIGN
-  STORE_MOVE_ASSIGN
-  STORE_CONST_MOVE_ASSIGN
-};
-// NOLINTEND(cppcoreguidelines-special-member-functions,
-// google-explicit-constructor)
-
-#if !defined(CEXA_HAS_CXX20)
-template <bool bt1, bool bt2, bool bt3, bool bt4, class T, class... TTypes,
-          bool bu1, bool bu2, bool bu3, bool bu4, class U, class... UTypes>
-KOKKOS_INLINE_FUNCTION constexpr bool operator==(
-    const store<Bools<bt1, bt2, bt3, bt4>, T, TTypes...>& lhs,
-    const store<Bools<bu1, bu2, bu3, bu4>, U, UTypes...>& rhs) {
-  return lhs.value == rhs.value && lhs.rest == rhs.rest;
-}
-
-template <bool bt1, bool bt2, bool bt3, bool bt4, class T, class... TTypes,
-          bool bu1, bool bu2, bool bu3, bool bu4, class U, class... UTypes>
-KOKKOS_INLINE_FUNCTION constexpr bool operator<(
-    const store<Bools<bt1, bt2, bt3, bt4>, T, TTypes...>& lhs,
-    const store<Bools<bu1, bu2, bu3, bu4>, U, UTypes...>& rhs) {
-  if (lhs.value < rhs.value) {
+  KOKKOS_INLINE_FUNCTION friend constexpr bool operator==(const store<>&,
+                                                          const store<>&) {
     return true;
-  } else if (lhs.value > rhs.value) {
+  }
+  KOKKOS_INLINE_FUNCTION friend constexpr bool operator<(const store<>&,
+                                                         const store<>&) {
     return false;
-  } else {
-    return lhs.rest < rhs.rest;
-  }
-}
-#endif
-
-#undef STORE_CXX23_CONST_SWAP
-#undef STORE_CXX23_CONST_ASSIGN
-#undef STORE_COMMON_FUNCS
-#undef STORE_COPY_ASSIGN
-#undef STORE_CONST_COPY_ASSIGN
-#undef STORE_MOVE_ASSIGN
-#undef STORE_CONST_MOVE_ASSIGN
-#undef DELETED_STORE_COPY_ASSIGN
-#undef DELETED_STORE_CONST_COPY_ASSIGN
-#undef DELETED_STORE_MOVE_ASSIGN
-#undef DELETED_STORE_CONST_MOVE_ASSIGN
-
-#define TUPLE_ASSIGN_HELPER_CONSTRUCTORS                                  \
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper() noexcept =    \
-      default;                                                            \
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper(                \
-      const tuple_assign_helper&) noexcept = default;                     \
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper(                \
-      tuple_assign_helper&&) noexcept = default;                          \
-  KOKKOS_DEFAULTED_FUNCTION CEXA_CONSTEXPR_CXX20 ~tuple_assign_helper() = \
-      default;
-
-template <bool copy_assignable, bool const_copy_assignable,
-          bool move_assignable, bool const_move_assignable>
-struct tuple_assign_helper;
-
-template <>
-struct tuple_assign_helper<false, false, false, false> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  constexpr tuple_assign_helper& operator=(const tuple_assign_helper&) = delete;
-  constexpr tuple_assign_helper& operator=(tuple_assign_helper&&)      = delete;
-#if defined(CEXA_HAS_CXX23)
-
-#endif
-};
-
-template <>
-struct tuple_assign_helper<false, false, false, true> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  constexpr tuple_assign_helper& operator=(const tuple_assign_helper&) = delete;
-  constexpr tuple_assign_helper& operator=(tuple_assign_helper&&)      = delete;
-#if defined(CEXA_HAS_CXX23)
-
-  constexpr const tuple_assign_helper& operator=(
-      tuple_assign_helper&&) const noexcept {
-    return *this;
   }
 #endif
 };
 
-template <>
-struct tuple_assign_helper<false, false, true, false> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  constexpr tuple_assign_helper& operator=(const tuple_assign_helper&) = delete;
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      tuple_assign_helper&&) noexcept = default;
-#if defined(CEXA_HAS_CXX23)
+template <class T, class... Types>
+struct store<T, Types...> {
+  T value{};
+  store<Types...> rest;
 
-#endif
-};
+  KOKKOS_DEFAULTED_FUNCTION constexpr store() = default;
 
-template <>
-struct tuple_assign_helper<false, false, true, true> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  constexpr tuple_assign_helper& operator=(const tuple_assign_helper&) = delete;
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      tuple_assign_helper&&) noexcept = default;
-#if defined(CEXA_HAS_CXX23)
+  KOKKOS_DEFAULTED_FUNCTION constexpr store(const store& other) = default;
+  template <class Dummy = void,
+            class       = std::enable_if_t<std::is_same_v<Dummy, void> &&
+                                           std::is_move_constructible_v<T>>>
+  KOKKOS_INLINE_FUNCTION constexpr explicit store(store&& other)
+      : value(FWD(other.value)), rest(FWD(other.rest)) {}
 
-  constexpr const tuple_assign_helper& operator=(
-      tuple_assign_helper&&) const noexcept {
+  template <
+      typename U, typename... UTypes,
+      class = std::enable_if_t<!is_store_v<U> && (!is_store_v<UTypes> && ...)>>
+  KOKKOS_INLINE_FUNCTION constexpr store(U&& u, UTypes&&... args)
+      : value(FWD(u)), rest(FWD(args)...) {}
+
+  KOKKOS_DEFAULTED_FUNCTION constexpr ~store() = default;
+
+  template <
+      class U, class... UTypes,
+      class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
+                               !(std::is_same_v<U, T> &&
+                                 (std::is_same_v<UTypes, Types> && ...)) &&
+                               std::is_assignable_v<T&, const U&>>>
+  KOKKOS_INLINE_FUNCTION constexpr store& operator=(
+      const store<U, UTypes...>& other) {
+    value = other.value;
+    rest  = other.rest;
     return *this;
   }
-#endif
-};
-
-template <>
-struct tuple_assign_helper<false, true, false, false> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  constexpr tuple_assign_helper& operator=(const tuple_assign_helper&) = delete;
-  constexpr tuple_assign_helper& operator=(tuple_assign_helper&&)      = delete;
-#if defined(CEXA_HAS_CXX23)
-  constexpr const tuple_assign_helper& operator=(
-      const tuple_assign_helper&) const noexcept {
-    return *this;
-  }
-
-#endif
-};
-
-template <>
-struct tuple_assign_helper<false, true, false, true> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  constexpr tuple_assign_helper& operator=(const tuple_assign_helper&) = delete;
-  constexpr tuple_assign_helper& operator=(tuple_assign_helper&&)      = delete;
-#if defined(CEXA_HAS_CXX23)
-  constexpr const tuple_assign_helper& operator=(
-      const tuple_assign_helper&) const noexcept {
-    return *this;
-  }
-  constexpr const tuple_assign_helper& operator=(
-      tuple_assign_helper&&) const noexcept {
-    return *this;
-  }
-#endif
-};
-
-template <>
-struct tuple_assign_helper<false, true, true, false> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  constexpr tuple_assign_helper& operator=(const tuple_assign_helper&) = delete;
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      tuple_assign_helper&&) noexcept = default;
-#if defined(CEXA_HAS_CXX23)
-  constexpr const tuple_assign_helper& operator=(
-      const tuple_assign_helper&) const noexcept {
+  template <
+      class U, class... UTypes,
+      class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
+                               !(std::is_same_v<U, T> &&
+                                 (std::is_same_v<UTypes, Types> && ...)) &&
+                               std::is_assignable_v<T&, U&&>>>
+  KOKKOS_INLINE_FUNCTION constexpr store& operator=(
+      store<U, UTypes...>&& other) {
+    value = FWD(other.value);
+    rest  = std::move(other.rest);
     return *this;
   }
 
-#endif
-};
-
-template <>
-struct tuple_assign_helper<false, true, true, true> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  constexpr tuple_assign_helper& operator=(const tuple_assign_helper&) = delete;
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      tuple_assign_helper&&) noexcept = default;
-#if defined(CEXA_HAS_CXX23)
-  constexpr const tuple_assign_helper& operator=(
-      const tuple_assign_helper&) const noexcept {
+  KOKKOS_INLINE_FUNCTION constexpr store& operator=(
+      const store& other) noexcept(std::is_nothrow_copy_assignable_v<T> &&
+                                   (std::is_nothrow_copy_assignable_v<Types> &&
+                                    ...))
+    requires(std::is_copy_assignable_v<T>)
+  {
+    value = other.value;
+    rest  = other.rest;
     return *this;
   }
-  constexpr const tuple_assign_helper& operator=(
-      tuple_assign_helper&&) const noexcept {
+
+  KOKKOS_INLINE_FUNCTION constexpr store& operator=(store&& other) noexcept(
+      std::is_nothrow_move_assignable_v<T> &&
+      (std::is_nothrow_move_assignable_v<Types> && ...))
+    requires(std::is_move_assignable_v<T>)
+  {
+    value = std::move(other.value);
+    rest  = std::move(other.rest);
     return *this;
   }
-#endif
-};
 
-template <>
-struct tuple_assign_helper<true, false, false, false> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      const tuple_assign_helper&) noexcept                        = default;
-  constexpr tuple_assign_helper& operator=(tuple_assign_helper&&) = delete;
 #if defined(CEXA_HAS_CXX23)
-
-#endif
-};
-
-template <>
-struct tuple_assign_helper<true, false, false, true> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      const tuple_assign_helper&) noexcept                        = default;
-  constexpr tuple_assign_helper& operator=(tuple_assign_helper&&) = delete;
-#if defined(CEXA_HAS_CXX23)
-
-  constexpr const tuple_assign_helper& operator=(
-      tuple_assign_helper&&) const noexcept {
+  KOKKOS_INLINE_FUNCTION constexpr const store& operator=(
+      const store& other) const
+    requires(std::is_copy_assignable_v<const T>)
+  {
+    value = other.value;
+    rest  = other.rest;
     return *this;
   }
-#endif
-};
 
-template <>
-struct tuple_assign_helper<true, false, true, false> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      const tuple_assign_helper&) noexcept = default;
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      tuple_assign_helper&&) noexcept = default;
-#if defined(CEXA_HAS_CXX23)
+  KOKKOS_INLINE_FUNCTION constexpr const store& operator=(store&& other) const
+      noexcept(std::is_nothrow_move_assignable_v<const T> &&
+               (std::is_nothrow_move_assignable_v<const Types> && ...))
+    requires(std::is_assignable_v<const T&, T &&>)
+  {
+    value = std::move(other.value);
+    rest  = std::move(other.rest);
+    return *this;
+  }
 
-#endif
-};
-
-template <>
-struct tuple_assign_helper<true, false, true, true> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      const tuple_assign_helper&) noexcept = default;
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      tuple_assign_helper&&) noexcept = default;
-#if defined(CEXA_HAS_CXX23)
-
-  constexpr const tuple_assign_helper& operator=(
-      tuple_assign_helper&&) const noexcept {
+  template <
+      class U, class... UTypes,
+      class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
+                               !(std::is_same_v<U, T> &&
+                                 (std::is_same_v<UTypes, Types> && ...)) &&
+                               std::is_assignable_v<const T&, const U&>>>
+  KOKKOS_INLINE_FUNCTION constexpr const store& operator=(
+      const store<U, UTypes...>& other) const {
+    value = other.value;
+    rest  = other.rest;
+    return *this;
+  }
+  template <
+      class U, class... UTypes,
+      class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
+                               !(std::is_same_v<U, T> &&
+                                 (std::is_same_v<UTypes, Types> && ...)) &&
+                               std::is_assignable_v<const T&, U&&>>>
+  KOKKOS_INLINE_FUNCTION constexpr const store& operator=(
+      store<U, UTypes...>&& other) const {
+    value = FWD(other.value);
+    rest  = std::move(other.rest);
     return *this;
   }
 #endif
-};
 
-template <>
-struct tuple_assign_helper<true, true, false, false> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      const tuple_assign_helper&) noexcept                        = default;
-  constexpr tuple_assign_helper& operator=(tuple_assign_helper&&) = delete;
+  template <std::size_t I>
+  KOKKOS_INLINE_FUNCTION constexpr tuple_element_t<I, tuple<T, Types...>>&
+  get_value() noexcept {
+    if constexpr (I == 0) {
+      return value;
+    } else {
+      return rest.template get_value<I - 1>();
+    }
+  }
+
+  template <std::size_t I>
+  KOKKOS_INLINE_FUNCTION constexpr const tuple_element_t<I, tuple<T, Types...>>&
+  get_value() const noexcept {
+    if constexpr (I == 0) {
+      return value;
+    } else {
+      return rest.template get_value<I - 1>();
+    }
+  }
+
+  template <class Type>
+  KOKKOS_INLINE_FUNCTION constexpr Type& get_value() noexcept {
+    if constexpr (std::is_same_v<Type, T>) {
+      return value;
+    } else {
+      return rest.template get_value<Type>();
+    }
+  }
+
+  template <class Type>
+  KOKKOS_INLINE_FUNCTION constexpr const Type& get_value() const noexcept {
+    if constexpr (std::is_same_v<Type, T>) {
+      return value;
+    } else {
+      return rest.template get_value<Type>();
+    }
+  }
+
+  template <class U, class = std::enable_if_t<std::is_assignable_v<
+                         T&, decltype(std::forward<U>(std::declval<U&&>()))>>>
+  KOKKOS_INLINE_FUNCTION constexpr void set_all(U&& u) {
+    value = u;
+  }
+
+  template <class U, class... UTypes,
+            class = std::enable_if_t<std::is_assignable_v<
+                T&, decltype(std::forward<U>(std::declval<U&&>()))>>>
+  KOKKOS_INLINE_FUNCTION constexpr void set_all(U&& head, UTypes&&... tail) {
+    value = head;
+    rest.set_all(FWD(tail)...);
+  }
+
+  template <class UTuple>
+  constexpr void set(UTuple&& u) {
+    set(FWD(u), std::make_index_sequence<1 + sizeof...(Types)>{});
+  }
+
+  template <class UTuple, std::size_t... Ints>
+  constexpr void set(UTuple&& u, std::index_sequence<Ints...>) {
+    set_all(get<Ints>(FWD(u))...);
+  }
+
+  KOKKOS_INLINE_FUNCTION constexpr void swap(store& rhs) noexcept(
+      std::is_nothrow_swappable_v<T> &&
+      (std::is_nothrow_swappable_v<Types> && ...)) {
+    using std::swap;
+    swap(value, rhs.value);
+    rest.swap(rhs.rest);
+  }
+
 #if defined(CEXA_HAS_CXX23)
-  constexpr const tuple_assign_helper& operator=(
-      const tuple_assign_helper&) const noexcept {
-    return *this;
+  KOKKOS_INLINE_FUNCTION constexpr void swap(const store& rhs) const
+      noexcept(std::is_nothrow_swappable_v<const T> &&
+               (std::is_nothrow_swappable_v<const Types> && ...)) {
+    using std::swap;
+    swap(value, rhs.value);
+    rest.swap(rhs.rest);
   }
 
 #endif
-};
 
-template <>
-struct tuple_assign_helper<true, true, false, true> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      const tuple_assign_helper&) noexcept                        = default;
-  constexpr tuple_assign_helper& operator=(tuple_assign_helper&&) = delete;
-#if defined(CEXA_HAS_CXX23)
-  constexpr const tuple_assign_helper& operator=(
-      const tuple_assign_helper&) const noexcept {
-    return *this;
+#if defined(CEXA_TUPLE_IMPL_USE_SPACESHIP_OPERATOR)
+  template <class U, class... UTypes>
+    requires std::three_way_comparable_with<T, U>
+  KOKKOS_INLINE_FUNCTION constexpr auto operator<=>(
+      const store<U, UTypes...>& rhs) const
+      -> std::common_comparison_category_t<decltype(value <=> rhs.value),
+                                           decltype(rest <=> rhs.rest)> {
+    auto res = value <=> rhs.value;
+    return res != 0 ? res : rest <=> rhs.rest;
   }
-  constexpr const tuple_assign_helper& operator=(
-      tuple_assign_helper&&) const noexcept {
-    return *this;
+  template <class U, class... UTypes>
+  KOKKOS_INLINE_FUNCTION constexpr std::weak_ordering operator<=>(
+      const store<U, UTypes...>& rhs) const {
+    if (value < rhs.value) {
+      return std::weak_ordering::less;
+    } else if (rhs.value < value) {
+      return std::weak_ordering::greater;
+    } else {
+      return static_cast<std::weak_ordering>(rest <=> rhs.rest);
+    }
   }
-#endif
-};
-
-template <>
-struct tuple_assign_helper<true, true, true, false> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      const tuple_assign_helper&) noexcept = default;
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      tuple_assign_helper&&) noexcept = default;
-#if defined(CEXA_HAS_CXX23)
-  constexpr const tuple_assign_helper& operator=(
-      const tuple_assign_helper&) const noexcept {
-    return *this;
+  template <class U, class... UTypes>
+  KOKKOS_INLINE_FUNCTION constexpr bool operator==(
+      const store<U, UTypes...>& rhs) const {
+    return operator<=>(rhs) == 0;
   }
-
-#endif
-};
-
-template <>
-struct tuple_assign_helper<true, true, true, true> {
-  TUPLE_ASSIGN_HELPER_CONSTRUCTORS
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      const tuple_assign_helper&) noexcept = default;
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple_assign_helper& operator=(
-      tuple_assign_helper&&) noexcept = default;
-#if defined(CEXA_HAS_CXX23)
-  constexpr const tuple_assign_helper& operator=(
-      const tuple_assign_helper&) const noexcept {
-    return *this;
+#else
+  template <class U, class... UTypes>
+  KOKKOS_INLINE_FUNCTION constexpr bool operator==(
+      const store<U, UTypes...>& rhs) const {
+    return value == rhs.value && rest == rhs.rest;
   }
-  constexpr const tuple_assign_helper& operator=(
-      tuple_assign_helper&&) const noexcept {
-    return *this;
+  template <class U, class... UTypes>
+  KOKKOS_INLINE_FUNCTION constexpr bool operator<(
+      const store<U, UTypes...>& rhs) const {
+    return value < rhs.value || (value == rhs.value && rest < rhs.rest);
   }
 #endif
 };
-
-#undef TUPLE_ASSIGN_HELPER_CONSTRUCTORS
 }  // namespace impl
 
-#if defined(CEXA_HAS_CXX20)
-#define CEXA_EXPLICIT(expr) explicit(expr)
-#else
-// #define CEXA_EXPLICIT(expr) explicit
-#define CEXA_EXPLICIT(expr)
-#endif
-
-template <typename... Types>
+template <class... Types>
 class tuple;
 
 template <>
 class tuple<> {
  public:
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple() = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple() noexcept = default;
 
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple(const tuple& u)     = default;
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple(tuple&& u) noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple(const tuple& u) noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple(tuple&& u) noexcept      = default;
 
-  KOKKOS_DEFAULTED_FUNCTION CEXA_CONSTEXPR_CXX20 ~tuple() = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr ~tuple() = default;
 
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(const tuple& u) =
-      default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(
+      const tuple& u) noexcept = default;
   KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(tuple&& u) noexcept =
       default;
+#if defined(CEXA_HAS_CXX23)
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(
+      const tuple& u) const noexcept = default;
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(
+      tuple&& u) const noexcept = default;
+#endif
 
   KOKKOS_INLINE_FUNCTION constexpr void swap(tuple&) noexcept {}
 #if defined(CEXA_HAS_CXX23)
   KOKKOS_INLINE_FUNCTION constexpr void swap(const tuple&) const noexcept {}
 #endif
-#if defined(CEXA_HAS_CXX20)
+
+#if defined(CEXA_TUPLE_IMPL_USE_SPACESHIP_OPERATOR)
   KOKKOS_DEFAULTED_FUNCTION auto operator<=>(const tuple&) const = default;
 #endif
 };
 
-#if !defined(CEXA_HAS_CXX20)
+#if !defined(CEXA_TUPLE_IMPL_USE_SPACESHIP_OPERATOR)
 KOKKOS_INLINE_FUNCTION constexpr bool operator==(const tuple<>&,
                                                  const tuple<>&) {
   return true;
 }
-
+KOKKOS_INLINE_FUNCTION constexpr bool operator!=(const tuple<>&,
+                                                 const tuple<>&) {
+  return false;
+}
 KOKKOS_INLINE_FUNCTION constexpr bool operator<(const tuple<>&,
                                                 const tuple<>&) {
   return false;
+}
+KOKKOS_INLINE_FUNCTION constexpr bool operator<=(const tuple<>&,
+                                                 const tuple<>&) {
+  return true;
+}
+KOKKOS_INLINE_FUNCTION constexpr bool operator>(const tuple<>&,
+                                                const tuple<>&) {
+  return false;
+}
+KOKKOS_INLINE_FUNCTION constexpr bool operator>=(const tuple<>&,
+                                                 const tuple<>&) {
+  return true;
 }
 #endif
 
@@ -976,13 +467,8 @@ template <typename... Types>
 // NOTE: move ctor is defined but not detected by clang-tidy, assignment ops are
 // intentionally not defined, so that the compiler can default/delete them based
 // on what's done inside tuple_assign_helper
-// NOLINTNEXTLINE(cppcoreguidelines-special-member-functions)
-class tuple
-    : impl::tuple_assign_helper<
-          std::conjunction_v<std::is_copy_assignable<Types>...>,
-          std::conjunction_v<std::is_copy_assignable<const Types>...>,
-          std::conjunction_v<std::is_move_assignable<Types>...>,
-          std::conjunction_v<std::is_assignable<const Types&, Types&&>...>> {
+// NO_NO_LINT_NEXTLINE(cppcoreguidelines-special-member-functions)
+class tuple {
  private:
   template <typename... Ts>
   using T0 = typename impl::nth_type<0, Ts...>::type;
@@ -995,7 +481,7 @@ class tuple
   template <class... UTypes>
   friend class tuple;
 
-  impl::store_<Types...> values;
+  impl::store<Types...> values;
 
 // NOLINTBEGIN(bugprone-macro-parentheses)
 #define CONVERTING_TUPLE_CTOR_CONSTRAINTS(CONST, REF)                    \
@@ -1035,7 +521,7 @@ class tuple
                   std::is_same<T0<Types...>, T0<UTypes...>>>>>,                \
           std::negation<impl::any_types_reference_constructs_from_temporary<   \
               tuple<Types...>, CONST tuple<UTypes...> REF>>>>>                 \
-  KOKKOS_INLINE_FUNCTION CEXA_EXPLICIT(                                        \
+  KOKKOS_INLINE_FUNCTION explicit(                                             \
       !(impl::all_types_convertible_v<                                         \
           CONST tuple<UTypes...> REF,                                          \
           tuple<Types...>>)) constexpr tuple(CONST tuple<UTypes...> REF other) \
@@ -1079,7 +565,7 @@ class tuple
                     T1<Types...>,                                            \
                     decltype(std::get<1>(FWD(                                \
                         (std::declval<CONST std::pair<U1, U2> REF>()))))>>>  \
-  inline constexpr CEXA_EXPLICIT(                                            \
+  inline constexpr explicit(                                                 \
       (!std::is_convertible_v<                                               \
            decltype(std::get<0>(                                             \
                FWD((std::declval<CONST std::pair<U1, U2> REF>())))),         \
@@ -1106,7 +592,7 @@ class tuple
       class Dummy = void,
       class       = std::enable_if_t<std::conjunction_v<
                 std::is_same<Dummy, void>, std::is_default_constructible<Types>...>>>
-  KOKKOS_INLINE_FUNCTION CEXA_EXPLICIT(
+  KOKKOS_INLINE_FUNCTION explicit(
       (!impl::empty_copy_list_initializable_v<Types> ||
        ...)) constexpr tuple() noexcept((std::
                                              is_nothrow_default_constructible_v<
@@ -1119,12 +605,12 @@ class tuple
       class       = std::enable_if_t<std::is_same_v<Dummy, void> &&
                                      (sizeof...(Types) >= 1 &&
                                 (std::is_copy_constructible_v<Types> && ...))>>
-  KOKKOS_INLINE_FUNCTION
-  CEXA_EXPLICIT((!std::is_convertible_v<const Types&, Types> || ...)) constexpr tuple(
-      const Types&... vals) noexcept((std::
-                                          is_nothrow_copy_constructible_v<
-                                              Types> &&
-                                      ...))
+  KOKKOS_INLINE_FUNCTION explicit((
+      !std::is_convertible_v<const Types&, Types> ||
+      ...)) constexpr tuple(const Types&... vals) noexcept((std::
+                                                                is_nothrow_copy_constructible_v<
+                                                                    Types> &&
+                                                            ...))
       : values(vals...) {}
 
   template <
@@ -1136,24 +622,22 @@ class tuple
               std::conjunction<std::is_same<UTypes&&, const Types&>...>>,
           std::conditional_t<
               sizeof...(Types) == 1,
-              std::negation<std::is_same<impl::remove_cvref_t<T0<UTypes...>>,
+              std::negation<std::is_same<std::remove_cvref_t<T0<UTypes...>>,
                                          tuple<Types...>>>,
               std::true_type>,
-          std::conditional_t<
-              sizeof...(Types) == 2 ||
-                  sizeof...(Types) == 3,
-              std::disjunction<std::negation<std::is_same<
-                                   impl::remove_cvref_t<T0<UTypes...>>,
-                                   std::allocator_arg_t>>,
-                               std::is_same<impl::remove_cvref_t<T0<Types...>>,
-                                            std::allocator_arg_t>>,
-              std::true_type>,
+          std::conditional_t<sizeof...(Types) == 2 || sizeof...(Types) == 3,
+                             std::disjunction<
+                                 std::negation<std::is_same<
+                                     std::remove_cvref_t<T0<UTypes...>>,
+                                     std::allocator_arg_t>>,
+                                 std::is_same<std::remove_cvref_t<T0<Types...>>,
+                                              std::allocator_arg_t>>,
+                             std::true_type>,
           std::negation<
               impl::reference_constructs_from_temporary<Types, UTypes&&>>...,
           std::is_constructible<Types, UTypes>...>>>
-  KOKKOS_INLINE_FUNCTION CEXA_EXPLICIT(
-      (!std::is_convertible_v<UTypes&&, Types> ||
-       ...)) constexpr tuple(UTypes&&... args)
+  KOKKOS_INLINE_FUNCTION explicit((!std::is_convertible_v<UTypes&&, Types> ||
+                                   ...)) constexpr tuple(UTypes&&... args)
       : values(FWD(args)...) {}
 
   KOKKOS_DEFAULTED_FUNCTION constexpr tuple(const tuple& u) = default;
@@ -1167,7 +651,7 @@ class tuple
       : values(std::move(u.values)) {}
 
   template <class... UTypes, CONVERTING_TUPLE_CTOR_CONSTRAINTS(const, &)>
-  KOKKOS_INLINE_FUNCTION CEXA_EXPLICIT(
+  KOKKOS_INLINE_FUNCTION explicit(
       !(impl::all_types_convertible_v<
           const tuple<UTypes...>&,
           tuple<Types...>>)) constexpr tuple(const tuple<UTypes...>& other)
@@ -1175,7 +659,7 @@ class tuple
               std::make_index_sequence<sizeof...(Types)>{}) {}
 
   template <class... UTypes, CONVERTING_TUPLE_CTOR_CONSTRAINTS(, &&)>
-  KOKKOS_INLINE_FUNCTION CEXA_EXPLICIT(
+  KOKKOS_INLINE_FUNCTION explicit(
       !(impl::all_types_convertible_v<
           tuple<UTypes...>&&,
           tuple<Types...>>)) constexpr tuple(tuple<UTypes...>&& other)
@@ -1184,7 +668,7 @@ class tuple
 
 #if defined(CEXA_HAS_CXX23)
   template <class... UTypes, CONVERTING_TUPLE_CTOR_CONSTRAINTS(, &)>
-  KOKKOS_INLINE_FUNCTION CEXA_EXPLICIT(
+  KOKKOS_INLINE_FUNCTION explicit(
       !(impl::all_types_convertible_v<
           tuple<UTypes...>&,
           tuple<Types...>>)) constexpr tuple(tuple<UTypes...>& other)
@@ -1192,7 +676,7 @@ class tuple
               std::make_index_sequence<sizeof...(Types)>{}) {}
 
   template <class... UTypes, CONVERTING_TUPLE_CTOR_CONSTRAINTS(const, &&)>
-  KOKKOS_INLINE_FUNCTION CEXA_EXPLICIT(
+  KOKKOS_INLINE_FUNCTION explicit(
       !(impl::all_types_convertible_v<
           const tuple<UTypes...>&&,
           tuple<Types...>>)) constexpr tuple(const tuple<UTypes...>&& other)
@@ -1207,7 +691,7 @@ class tuple
   // #endif
 
   template <class U1, class U2, PAIR_CTOR_CONSTRAINTS(const, &)>
-  constexpr CEXA_EXPLICIT(
+  constexpr explicit(
       (!std::is_convertible_v<decltype(std::get<0>(FWD(
                                   (std::declval<const std::pair<U1, U2>&>())))),
                               T0<Types...>> ||
@@ -1217,7 +701,7 @@ class tuple
       : values(u.first, u.second) {}
 
   template <class U1, class U2, PAIR_CTOR_CONSTRAINTS(, &&)>
-  constexpr CEXA_EXPLICIT(
+  constexpr explicit(
       (!std::is_convertible_v<
            decltype(std::get<0>(FWD((std::declval<std::pair<U1, U2>&&>())))),
            T0<Types...>> ||
@@ -1229,7 +713,7 @@ class tuple
 
 #if defined(CEXA_HAS_CXX23)
   template <class U1, class U2, PAIR_CTOR_CONSTRAINTS(, &)>
-  constexpr CEXA_EXPLICIT(
+  constexpr explicit(
       (!std::is_convertible_v<
            decltype(std::get<0>(FWD((std::declval<std::pair<U1, U2>&>())))),
            T0<Types...>> ||
@@ -1239,7 +723,7 @@ class tuple
       : values(u.first, u.second) {}
 
   template <class U1, class U2, PAIR_CTOR_CONSTRAINTS(const, &&)>
-  constexpr CEXA_EXPLICIT((
+  constexpr explicit((
       !std::is_convertible_v<decltype(std::get<0>(FWD(
                                  (std::declval<const std::pair<U1, U2>&&>())))),
                              T0<Types...>> ||
@@ -1264,25 +748,22 @@ class tuple
               sizeof...(Types) ==
               tuple_size<std::remove_reference_t<UTuple>>::value>,
           impl::all_types_constructible<tuple<Types...>, UTuple&&>,
-          std::negation<impl::is_tuple<impl::remove_cvref_t<UTuple>>>,
-          std::negation<impl::is_subrange<impl::remove_cvref_t<UTuple>>>,
+          std::negation<impl::is_tuple<std::remove_cvref_t<UTuple>>>,
+          std::negation<impl::is_subrange<std::remove_cvref_t<UTuple>>>,
           std::negation<impl::any_types_reference_constructs_from_temporary<
               tuple<Types...>, UTuple>>,
           std::conjunction<std::bool_constant<sizeof...(Types) != 1>,
                            std::negation<std::disjunction<
                                std::is_convertible<UTuple, T0<Types...>>,
                                std::is_constructible<T0<Types...>, UTuple>>>>>>>
-  constexpr CEXA_EXPLICIT(
+  constexpr explicit(
       (!impl::all_types_convertible_v<UTuple&&, tuple<Types...>>))
       tuple(UTuple&& u)
       : tuple(tuple_like_tag{}, FWD(u),
               std::make_index_sequence<sizeof...(Types)>{}) {}
 
   KOKKOS_DEFAULTED_FUNCTION
-#if defined(CEXA_HAS_CXX20)
-  constexpr
-#endif
-      ~tuple() = default;
+  constexpr ~tuple() = default;
 
 #undef CONVERTING_TUPLE_CTOR_CONSTRAINTS
 #undef PAIR_CTOR_CONSTRAINTS
@@ -1290,6 +771,25 @@ class tuple
 #undef IMPL_PAIR_CONSTRUCTOR
 
   // tuple.assign
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(const tuple& u)
+    requires(std::is_copy_assignable_v<Types> && ...)
+  = default;
+
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(tuple&& u) noexcept(
+      (std::is_nothrow_move_assignable_v<Types> && ...))
+    requires(std::is_move_assignable_v<Types> && ...)
+  = default;
+
+#if defined(CEXA_HAS_CXX23)
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(const tuple& u) const
+    requires(std::is_copy_assignable_v<const Types> && ...)
+  = default;
+
+  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(tuple&& u) const
+    requires(std::is_assignable_v<const Types&, Types> && ...)
+  = default;
+#endif
+
   template <class... UTypes,
             class = std::enable_if_t<std::conjunction_v<
                 std::bool_constant<sizeof...(Types) == sizeof...(UTypes)>,
@@ -1402,8 +902,8 @@ class tuple
   template <class UTuple,
             class = std::enable_if_t<
                 impl::is_tuple_like_v<UTuple> &&
-                !impl::is_tuple_v<impl::remove_cvref_t<UTuple>> &&
-                !impl::is_pair<impl::remove_cvref_t<UTuple>>::value &&
+                !impl::is_tuple_v<std::remove_cvref_t<UTuple>> &&
+                !impl::is_pair<std::remove_cvref_t<UTuple>>::value &&
                 impl::is_different_from_v<UTuple, tuple> &&
                 !impl::is_subrange_v<UTuple> &&
                 sizeof...(Types) ==
@@ -1418,10 +918,10 @@ class tuple
   template <class UTuple,
             class = std::enable_if_t<
                 impl::is_tuple_like_v<UTuple> &&
-                !impl::is_tuple_v<impl::remove_cvref_t<UTuple>> &&
-                !impl::is_pair<impl::remove_cvref_t<UTuple>>::value &&
+                !impl::is_tuple_v<std::remove_cvref_t<UTuple>> &&
+                !impl::is_pair<std::remove_cvref_t<UTuple>>::value &&
                 impl::is_different_from_v<UTuple, tuple> &&
-                !impl::is_subrange_v<impl::remove_cvref_t<UTuple>> &&
+                !impl::is_subrange_v<std::remove_cvref_t<UTuple>> &&
                 sizeof...(Types) ==
                     tuple_size<std::remove_reference_t<UTuple>>::value>>
   // The check for is_assignable is delegated to store.set_all()
@@ -1479,7 +979,7 @@ class tuple
   get(const tuple<Ts...>&& t) noexcept;
 
   // tuple.rel
-#if defined(CEXA_HAS_CXX20)
+#if defined(CEXA_TUPLE_IMPL_USE_SPACESHIP_OPERATOR)
   template <class... UTypes>
     requires(sizeof...(Types) == sizeof...(UTypes))
   KOKKOS_INLINE_FUNCTION constexpr auto operator<=>(
@@ -1494,13 +994,42 @@ class tuple
     return (values <=> rhs.values) == 0;
   }
 #else
-  template <class... TTypes, class... UTypes>
-  KOKKOS_INLINE_FUNCTION friend constexpr bool operator==(
-      const tuple<TTypes...>& lhs, const tuple<UTypes...>& rhs);
-
-  template <class... TTypes, class... UTypes>
-  KOKKOS_INLINE_FUNCTION friend constexpr bool operator<(
-      const tuple<TTypes...>& lhs, const tuple<UTypes...>& rhs);
+  template <class... UTypes>
+    requires(sizeof...(Types) == sizeof...(UTypes))
+  KOKKOS_INLINE_FUNCTION constexpr bool operator==(
+      const tuple<UTypes...>& rhs) const {
+    return values == rhs.values;
+  }
+  template <class... UTypes>
+    requires(sizeof...(Types) == sizeof...(UTypes))
+  KOKKOS_INLINE_FUNCTION constexpr bool operator!=(
+      const tuple<UTypes...>& rhs) const {
+    return !(values == rhs.values);
+  }
+  template <class... UTypes>
+    requires(sizeof...(Types) == sizeof...(UTypes))
+  KOKKOS_INLINE_FUNCTION constexpr bool operator<(
+      const tuple<UTypes...>& rhs) const {
+    return values < rhs.values;
+  }
+  template <class... UTypes>
+    requires(sizeof...(Types) == sizeof...(UTypes))
+  KOKKOS_INLINE_FUNCTION constexpr bool operator<=(
+      const tuple<UTypes...>& rhs) const {
+    return !(rhs.values < values);
+  }
+  template <class... UTypes>
+    requires(sizeof...(Types) == sizeof...(UTypes))
+  KOKKOS_INLINE_FUNCTION constexpr bool operator>(
+      const tuple<UTypes...>& rhs) const {
+    return rhs.values < values;
+  }
+  template <class... UTypes>
+    requires(sizeof...(Types) == sizeof...(UTypes))
+  KOKKOS_INLINE_FUNCTION constexpr bool operator>=(
+      const tuple<UTypes...>& rhs) const {
+    return !(values < rhs.values);
+  }
 #endif
 };
 
@@ -1568,47 +1097,6 @@ get(const tuple<Types...>&& t) noexcept {
   return static_cast<const T&&>(t.values.template get_value<T>());
 }
 
-// tuple.rel
-#if !defined(CEXA_HAS_CXX20)
-template <class... TTypes, class... UTypes>
-KOKKOS_INLINE_FUNCTION constexpr bool operator==(const tuple<TTypes...>& lhs,
-                                                 const tuple<UTypes...>& rhs) {
-  static_assert(sizeof...(TTypes) == sizeof...(UTypes), "");
-  return lhs.values == rhs.values;
-}
-
-template <class... TTypes, class... UTypes>
-KOKKOS_INLINE_FUNCTION constexpr bool operator!=(const tuple<TTypes...>& lhs,
-                                                 const tuple<UTypes...>& rhs) {
-  return !(lhs == rhs);
-}
-
-template <class... TTypes, class... UTypes>
-KOKKOS_INLINE_FUNCTION constexpr bool operator<(const tuple<TTypes...>& lhs,
-                                                const tuple<UTypes...>& rhs) {
-  static_assert(sizeof...(TTypes) == sizeof...(UTypes), "");
-  return lhs.values < rhs.values;
-}
-
-template <class... TTypes, class... UTypes>
-KOKKOS_INLINE_FUNCTION constexpr bool operator<=(const tuple<TTypes...>& lhs,
-                                                 const tuple<UTypes...>& rhs) {
-  return !(rhs < lhs);
-}
-
-template <class... TTypes, class... UTypes>
-KOKKOS_INLINE_FUNCTION constexpr bool operator>(const tuple<TTypes...>& lhs,
-                                                const tuple<UTypes...>& rhs) {
-  return rhs < lhs;
-}
-
-template <class... TTypes, class... UTypes>
-KOKKOS_INLINE_FUNCTION constexpr bool operator>=(const tuple<TTypes...>& lhs,
-                                                 const tuple<UTypes...>& rhs) {
-  return !(lhs < rhs);
-}
-#endif
-
 template <class... Types,
           class = std::enable_if_t<(std::is_swappable_v<Types> && ...)>>
 KOKKOS_INLINE_FUNCTION constexpr void swap(
@@ -1629,6 +1117,3 @@ swap(const tuple<Types...>& lhs, const tuple<Types...>& rhs) noexcept(
 #endif
 
 }  // namespace cexa
-
-#undef CEXA_EXPLICIT
-#undef CEXA_CONSTEXPR_CXX20

--- a/tuple/include/impl/tuple.hpp
+++ b/tuple/include/impl/tuple.hpp
@@ -128,8 +128,8 @@ struct store<> {
   KOKKOS_DEFAULTED_FUNCTION constexpr store(const store&) = default;
   KOKKOS_DEFAULTED_FUNCTION constexpr store(store&&)      = default;
 #if defined(CEXA_HAS_CXX23)
-  KOKKOS_DEFAULTED_FUNCTION constexpr store(store&) noexcept {}
-  KOKKOS_DEFAULTED_FUNCTION constexpr store(const store&&) noexcept {};
+  KOKKOS_DEFAULTED_FUNCTION constexpr store(store&) noexcept = default;
+  KOKKOS_INLINE_FUNCTION constexpr store(const store&&) noexcept {};
 #endif
   KOKKOS_DEFAULTED_FUNCTION constexpr ~store() = default;
 
@@ -137,11 +137,13 @@ struct store<> {
   KOKKOS_DEFAULTED_FUNCTION constexpr store& operator=(store&&)      = default;
 
 #if defined(CEXA_HAS_CXX23)
-  KOKKOS_DEFAULTED_FUNCTION constexpr const store& operator=(
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
+  KOKKOS_INLINE_FUNCTION constexpr const store& operator=(
       const store&) const noexcept {
     return *this;
   }
-  KOKKOS_DEFAULTED_FUNCTION constexpr const store& operator=(
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
+  KOKKOS_INLINE_FUNCTION constexpr const store& operator=(
       store&&) const noexcept {
     return *this;
   }
@@ -174,16 +176,19 @@ struct store<T, Types...> {
   KOKKOS_DEFAULTED_FUNCTION constexpr store() = default;
 
   KOKKOS_DEFAULTED_FUNCTION constexpr store(const store& other) = default;
-  template <class Dummy = void,
-            class       = std::enable_if_t<std::is_same_v<Dummy, void> &&
-                                           std::is_move_constructible_v<T>>>
-  KOKKOS_INLINE_FUNCTION constexpr explicit store(store&& other)
+
+  KOKKOS_INLINE_FUNCTION constexpr store(store&& other) noexcept(
+      std::is_nothrow_move_constructible_v<T> &&
+      (std::is_nothrow_move_constructible_v<Types> && ...))
       : value(FWD(other.value)), rest(FWD(other.rest)) {}
 
-  template <
-      typename U, typename... UTypes,
-      class = std::enable_if_t<!is_store_v<U> && (!is_store_v<UTypes> && ...)>>
-  KOKKOS_INLINE_FUNCTION constexpr store(U&& u, UTypes&&... args)
+  template <typename U, typename... UTypes>
+    requires(!is_store_v<U> && (!is_store_v<UTypes> && ...))
+  KOKKOS_INLINE_FUNCTION constexpr explicit store(
+      U&& u,
+      UTypes&&... args) noexcept(std::is_nothrow_move_constructible_v<T> &&
+                                 (std::is_nothrow_move_constructible_v<Types> &&
+                                  ...))
       : value(FWD(u)), rest(FWD(args)...) {}
 
   KOKKOS_DEFAULTED_FUNCTION constexpr ~store() = default;
@@ -213,6 +218,9 @@ struct store<T, Types...> {
     return *this;
   }
 
+  // FIXME: defaulting this operator leads to compile errors where the
+  // generated constructor would be ill-formed
+  // NOLINTNEXTLINE(hicpp-use-equals-default, modernize-use-equals-default)
   KOKKOS_INLINE_FUNCTION constexpr store& operator=(
       const store& other) noexcept(std::is_nothrow_copy_assignable_v<T> &&
                                    (std::is_nothrow_copy_assignable_v<Types> &&
@@ -420,10 +428,14 @@ class tuple<> {
   KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(tuple&& u) noexcept =
       default;
 #if defined(CEXA_HAS_CXX23)
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(
-      const tuple& u) const noexcept = default;
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(
-      tuple&& u) const noexcept = default;
+  KOKKOS_INLINE_FUNCTION constexpr const tuple& operator=(
+      const tuple& u) const noexcept {
+    return *this;
+  }
+  KOKKOS_INLINE_FUNCTION constexpr const tuple& operator=(
+      tuple&& u) const noexcept {
+    return *this;
+  }
 #endif
 
   KOKKOS_INLINE_FUNCTION constexpr void swap(tuple&) noexcept {}
@@ -463,26 +475,8 @@ KOKKOS_INLINE_FUNCTION constexpr bool operator>=(const tuple<>&,
 }
 #endif
 
-template <typename... Types>
-// NOTE: move ctor is defined but not detected by clang-tidy, assignment ops are
-// intentionally not defined, so that the compiler can default/delete them based
-// on what's done inside tuple_assign_helper
-// NO_NO_LINT_NEXTLINE(cppcoreguidelines-special-member-functions)
-class tuple {
- private:
-  template <typename... Ts>
-  using T0 = typename impl::nth_type<0, Ts...>::type;
-  template <typename... Ts>
-  using T1 = typename impl::nth_type<sizeof...(Ts) == 1 ? 0 : 1, Ts...>::type;
-
-  struct converting_tag {};
-  struct tuple_like_tag {};
-
-  template <class... UTypes>
-  friend class tuple;
-
-  impl::store<Types...> values;
-
+namespace impl {
+// We use sfinae instead of a concept since the concept would depend on itself
 // NOLINTBEGIN(bugprone-macro-parentheses)
 #define CONVERTING_TUPLE_CTOR_CONSTRAINTS(CONST, REF)                    \
   class = std::enable_if_t<std::conjunction_v<                           \
@@ -501,81 +495,52 @@ class tuple {
               std::is_same<T0<Types...>, T0<UTypes...>>>>>,              \
       std::negation<impl::any_types_reference_constructs_from_temporary< \
           tuple<Types...>, CONST tuple<UTypes...> REF>>>>
-#define IMPL_CONVERTING_TUPLE_CONSTRUCTOR(CONST, REF)                          \
- public:                                                                       \
-  template <                                                                   \
-      typename... UTypes,                                                      \
-      class = std::enable_if_t<std::conjunction_v<                             \
-          std::bool_constant<sizeof...(Types) == sizeof...(UTypes)>,           \
-          impl::all_types_constructible<tuple<Types...>,                       \
-                                        CONST tuple<UTypes...> REF>,           \
-          std::disjunction<                                                    \
-              std::bool_constant<sizeof...(Types) != 1>,                       \
-              std::negation<std::disjunction<                                  \
-                  std::is_convertible<                                         \
-                      decltype(std::declval<CONST tuple<UTypes...> REF>()),    \
-                      T0<Types...>>,                                           \
-                  std::is_constructible<                                       \
-                      T0<Types...>,                                            \
-                      decltype(std::declval<CONST tuple<UTypes...> REF>())>,   \
-                  std::is_same<T0<Types...>, T0<UTypes...>>>>>,                \
-          std::negation<impl::any_types_reference_constructs_from_temporary<   \
-              tuple<Types...>, CONST tuple<UTypes...> REF>>>>>                 \
-  KOKKOS_INLINE_FUNCTION explicit(                                             \
-      !(impl::all_types_convertible_v<                                         \
-          CONST tuple<UTypes...> REF,                                          \
-          tuple<Types...>>)) constexpr tuple(CONST tuple<UTypes...> REF other) \
-      : tuple(converting_tag{}, FWD(other),                                    \
-              std::make_index_sequence<sizeof...(Types)>{}) {}
+// NOLINTEND(bugprone-macro-parentheses)
 
-#define PAIR_CTOR_CONSTRAINTS(CONST, REF)                                  \
-  class = std::enable_if_t < sizeof...(Types) == 2 &&                      \
-          std::is_constructible_v<                                         \
-              T0<Types...>,                                                \
-              decltype(std::get<0>(                                        \
-                  FWD((std::declval<CONST std::pair<U1, U2> REF>()))))> && \
-          std::is_constructible_v<                                         \
-              T1<Types...>,                                                \
-              decltype(std::get<1>(                                        \
-                  FWD((std::declval<CONST std::pair<U1, U2> REF>()))))> && \
-          !impl::reference_constructs_from_temporary_v<                    \
-              T0<Types...>,                                                \
-              decltype(std::get<0>(                                        \
-                  FWD((std::declval<CONST std::pair<U1, U2> REF>()))))> && \
-          !impl::reference_constructs_from_temporary_v < T1<Types...>,     \
-  decltype(std::get<1>(FWD((std::declval<CONST std::pair<U1, U2> REF>())))) >>
+template <class Tuple, class UPair>
+concept pair_constructible =
+    tuple_size_v<Tuple> == 2 &&
+    std::constructible_from<tuple_element_t<0, std::remove_cvref_t<Tuple>>,
+                            decltype(std::get<0>(
+                                FWD((std::declval<UPair>()))))> &&
+    std::constructible_from<tuple_element_t<1, std::remove_cvref_t<Tuple>>,
+                            decltype(std::get<1>(
+                                FWD((std::declval<UPair>()))))> &&
+    !impl::reference_constructs_from_temporary_v<
+        tuple_element_t<0, std::remove_cvref_t<Tuple>>,
+        decltype(std::get<0>(FWD((std::declval<UPair>()))))> &&
+    !impl::reference_constructs_from_temporary_v<
+        tuple_element_t<1, std::remove_cvref_t<Tuple>>,
+        decltype(std::get<1>(FWD((std::declval<UPair>()))))>;
 
-#define IMPL_PAIR_CONSTRUCTOR(CONST, REF)                                    \
-  template <class U1, class U2,                                              \
-            class = std::enable_if_t<                                        \
-                sizeof...(Types) == 2 &&                                     \
-                std::is_constructible_v<                                     \
-                    T0<Types...>,                                            \
-                    decltype(std::get<0>(FWD(                                \
-                        (std::declval<CONST std::pair<U1, U2> REF>()))))> && \
-                std::is_constructible_v<                                     \
-                    T1<Types...>,                                            \
-                    decltype(std::get<1>(FWD(                                \
-                        (std::declval<CONST std::pair<U1, U2> REF>()))))> && \
-                !impl::reference_constructs_from_temporary_v<                \
-                    T0<Types...>,                                            \
-                    decltype(std::get<0>(FWD(                                \
-                        (std::declval<CONST std::pair<U1, U2> REF>()))))> && \
-                !impl::reference_constructs_from_temporary_v<                \
-                    T1<Types...>,                                            \
-                    decltype(std::get<1>(FWD(                                \
-                        (std::declval<CONST std::pair<U1, U2> REF>()))))>>>  \
-  inline constexpr explicit(                                                 \
-      (!std::is_convertible_v<                                               \
-           decltype(std::get<0>(                                             \
-               FWD((std::declval<CONST std::pair<U1, U2> REF>())))),         \
-           T0<Types...>> ||                                                  \
-       !std::is_convertible_v<                                               \
-           decltype(std::get<1>(                                             \
-               FWD((std::declval<CONST std::pair<U1, U2> REF>())))),         \
-           T1<Types...>>)) tuple(CONST std::pair<U1, U2> REF u)              \
-      : values(std::get<0>(FWD(u)), std::get<1>(FWD(u))) {}
-  // NOLINTEND(bugprone-macro-parentheses)
+template <class Tuple, class UTuple>
+concept tuple_like_constructible =
+    impl::is_tuple_like_v<UTuple> &&
+    tuple_size_v<Tuple> == tuple_size_v<std::remove_reference_t<UTuple>> &&
+    impl::all_types_constructible_v<Tuple, UTuple&&> &&
+    !impl::is_tuple_v<std::remove_cvref_t<UTuple>> &&
+    !impl::is_subrange_v<std::remove_cvref_t<UTuple>> &&
+    !impl::any_types_reference_constructs_from_temporary_v<Tuple, UTuple> &&
+    (tuple_size_v<Tuple> != 1 ||
+     !(std::convertible_to<UTuple, tuple_element_t<0, Tuple>> ||
+       std::constructible_from<tuple_element_t<0, Tuple>, UTuple>));
+}  // namespace impl
+
+template <typename... Types>
+class tuple {
+ private:
+  template <typename... Ts>
+  using T0 = typename impl::nth_type<0, Ts...>::type;
+  template <typename... Ts>
+  using T1 = typename impl::nth_type<sizeof...(Ts) == 1 ? 0 : 1, Ts...>::type;
+
+  struct converting_tag {};
+  struct tuple_like_tag {};
+
+  template <class... UTypes>
+  friend class tuple;
+
+  impl::store<Types...> values;
 
   template <class UTuple, std::size_t... Ints>
   KOKKOS_INLINE_FUNCTION constexpr tuple(converting_tag, UTuple&& u,
@@ -588,23 +553,19 @@ class tuple {
 
  public:
   // tuple.cnstr
-  template <
-      class Dummy = void,
-      class       = std::enable_if_t<std::conjunction_v<
-                std::is_same<Dummy, void>, std::is_default_constructible<Types>...>>>
   KOKKOS_INLINE_FUNCTION explicit(
       (!impl::empty_copy_list_initializable_v<Types> ||
        ...)) constexpr tuple() noexcept((std::
                                              is_nothrow_default_constructible_v<
                                                  Types> &&
                                          ...))
+    requires(std::is_default_constructible_v<Types> && ...)
       : values{} {}
 
-  template <
-      class Dummy = void,
-      class       = std::enable_if_t<std::is_same_v<Dummy, void> &&
-                                     (sizeof...(Types) >= 1 &&
-                                (std::is_copy_constructible_v<Types> && ...))>>
+  template <class Dummy = void,
+            class       = std::enable_if_t<
+                std::is_same_v<Dummy, void> && (sizeof...(Types) >= 1) &&
+                (std::is_copy_constructible_v<Types> && ...)>>
   KOKKOS_INLINE_FUNCTION explicit((
       !std::is_convertible_v<const Types&, Types> ||
       ...)) constexpr tuple(const Types&... vals) noexcept((std::
@@ -641,13 +602,10 @@ class tuple {
       : values(FWD(args)...) {}
 
   KOKKOS_DEFAULTED_FUNCTION constexpr tuple(const tuple& u) = default;
-  template <
-      class Dummy = void,
-      class       = std::enable_if_t<std::is_same_v<Dummy, void> &&
-                                     (std::is_move_constructible_v<Types> && ...)>>
-  // FIXME: give a reason why we can't mark this one explicit
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  KOKKOS_INLINE_FUNCTION constexpr tuple(tuple&& u)
+
+  KOKKOS_INLINE_FUNCTION constexpr tuple(tuple&& u) noexcept(
+      (std::is_nothrow_move_assignable_v<Types> && ...))
+    requires(std::move_constructible<Types> && ...)
       : values(std::move(u.values)) {}
 
   template <class... UTypes, CONVERTING_TUPLE_CTOR_CONSTRAINTS(const, &)>
@@ -683,14 +641,9 @@ class tuple {
       : tuple(converting_tag{}, std::move(other),
               std::make_index_sequence<sizeof...(Types)>{}) {}
 #endif
-  //   IMPL_CONVERTING_TUPLE_CONSTRUCTOR(const, &)
-  //   IMPL_CONVERTING_TUPLE_CONSTRUCTOR(, &&)
-  // #if defined(CEXA_HAS_CXX23)
-  //   IMPL_CONVERTING_TUPLE_CONSTRUCTOR(, &)
-  //   IMPL_CONVERTING_TUPLE_CONSTRUCTOR(const, &&)
-  // #endif
 
-  template <class U1, class U2, PAIR_CTOR_CONSTRAINTS(const, &)>
+  template <class U1, class U2>
+    requires impl::pair_constructible<tuple, const std::pair<U1, U2>&>
   constexpr explicit(
       (!std::is_convertible_v<decltype(std::get<0>(FWD(
                                   (std::declval<const std::pair<U1, U2>&>())))),
@@ -700,7 +653,8 @@ class tuple {
                               T1<Types...>>)) tuple(const std::pair<U1, U2>& u)
       : values(u.first, u.second) {}
 
-  template <class U1, class U2, PAIR_CTOR_CONSTRAINTS(, &&)>
+  template <class U1, class U2>
+    requires impl::pair_constructible<tuple, std::pair<U1, U2>&&>
   constexpr explicit(
       (!std::is_convertible_v<
            decltype(std::get<0>(FWD((std::declval<std::pair<U1, U2>&&>())))),
@@ -709,10 +663,11 @@ class tuple {
            decltype(std::get<1>(FWD((std::declval<std::pair<U1, U2>&&>())))),
            T1<Types...>>)) tuple(std::pair<U1, U2>&& u)
       : values(std::move(u.first), std::move(u.second)) {
-  }  // FIXME: see if we should use forward instead
+  }  // TODO: see if we should use forward instead
 
 #if defined(CEXA_HAS_CXX23)
-  template <class U1, class U2, PAIR_CTOR_CONSTRAINTS(, &)>
+  template <class U1, class U2>
+    requires impl::pair_constructible<tuple, std::pair<U1, U2>&>
   constexpr explicit(
       (!std::is_convertible_v<
            decltype(std::get<0>(FWD((std::declval<std::pair<U1, U2>&>())))),
@@ -722,7 +677,8 @@ class tuple {
            T1<Types...>>)) tuple(std::pair<U1, U2>& u)
       : values(u.first, u.second) {}
 
-  template <class U1, class U2, PAIR_CTOR_CONSTRAINTS(const, &&)>
+  template <class U1, class U2>
+    requires impl::pair_constructible<tuple, std::pair<U1, U2>&>
   constexpr explicit((
       !std::is_convertible_v<decltype(std::get<0>(FWD(
                                  (std::declval<const std::pair<U1, U2>&&>())))),
@@ -730,32 +686,11 @@ class tuple {
       !std::is_convertible_v<decltype(std::get<1>(FWD(
                                  (std::declval<const std::pair<U1, U2>&&>())))),
                              T1<Types...>>)) tuple(const std::pair<U1, U2>&& u)
-      : values(std::move(u.first), std::move(u.second)) {
-  }  // FIXME: see if we should use forward instead
+      : values(std::move(u.first), std::move(u.second)) {}
 #endif
-  //   IMPL_PAIR_CONSTRUCTOR(const, &)
-  //   IMPL_PAIR_CONSTRUCTOR(, &&)
-  // #if defined(CEXA_HAS_CXX23)
-  //   IMPL_PAIR_CONSTRUCTOR(, &)
-  //   IMPL_PAIR_CONSTRUCTOR(const, &&)
-  // #endif
 
-  template <
-      class UTuple,
-      class = std::enable_if_t<std::conjunction_v<
-          impl::is_tuple_like<UTuple>,
-          std::bool_constant<
-              sizeof...(Types) ==
-              tuple_size<std::remove_reference_t<UTuple>>::value>,
-          impl::all_types_constructible<tuple<Types...>, UTuple&&>,
-          std::negation<impl::is_tuple<std::remove_cvref_t<UTuple>>>,
-          std::negation<impl::is_subrange<std::remove_cvref_t<UTuple>>>,
-          std::negation<impl::any_types_reference_constructs_from_temporary<
-              tuple<Types...>, UTuple>>,
-          std::conjunction<std::bool_constant<sizeof...(Types) != 1>,
-                           std::negation<std::disjunction<
-                               std::is_convertible<UTuple, T0<Types...>>,
-                               std::is_constructible<T0<Types...>, UTuple>>>>>>>
+  template <class UTuple>
+    requires impl::tuple_like_constructible<tuple, UTuple>
   constexpr explicit(
       (!impl::all_types_convertible_v<UTuple&&, tuple<Types...>>))
       tuple(UTuple&& u)
@@ -764,11 +699,6 @@ class tuple {
 
   KOKKOS_DEFAULTED_FUNCTION
   constexpr ~tuple() = default;
-
-#undef CONVERTING_TUPLE_CTOR_CONSTRAINTS
-#undef PAIR_CTOR_CONSTRAINTS
-#undef IMPL_CONVERTING_TUPLE_CONSTRUCTOR
-#undef IMPL_PAIR_CONSTRUCTOR
 
   // tuple.assign
   KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(const tuple& u)
@@ -781,19 +711,25 @@ class tuple {
   = default;
 
 #if defined(CEXA_HAS_CXX23)
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(const tuple& u) const
+  KOKKOS_INLINE_FUNCTION constexpr const tuple& operator=(const tuple& u) const
     requires(std::is_copy_assignable_v<const Types> && ...)
-  = default;
+  {
+    values = u.values;
+    return *this;
+  }
 
-  KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(tuple&& u) const
+  KOKKOS_INLINE_FUNCTION constexpr const tuple& operator=(tuple&& u) const
+      noexcept((std::is_nothrow_move_assignable_v<const Types> && ...))
     requires(std::is_assignable_v<const Types&, Types> && ...)
-  = default;
+  {
+    values = std::move(u.values);
+    return *this;
+  }
 #endif
 
-  template <class... UTypes,
-            class = std::enable_if_t<std::conjunction_v<
-                std::bool_constant<sizeof...(Types) == sizeof...(UTypes)>,
-                std::is_assignable<Types&, const UTypes&>...>>>
+  template <class... UTypes>
+    requires(sizeof...(Types) == sizeof...(UTypes)) &&
+            std::conjunction_v<std::is_assignable<Types&, const UTypes&>...>
   KOKKOS_INLINE_FUNCTION constexpr tuple&
   operator=(const tuple<UTypes...>& other) noexcept(
       (std::is_nothrow_assignable_v<Types&, const UTypes&> && ...)) {
@@ -801,10 +737,9 @@ class tuple {
     return *this;
   }
 
-  template <class... UTypes,
-            class = std::enable_if_t<std::conjunction_v<
-                std::bool_constant<sizeof...(Types) == sizeof...(UTypes)>,
-                std::is_assignable<Types&, UTypes>...>>>
+  template <class... UTypes>
+    requires(sizeof...(Types) == sizeof...(UTypes)) &&
+            std::conjunction_v<std::is_assignable<Types&, UTypes>...>
   KOKKOS_INLINE_FUNCTION constexpr tuple&
   operator=(tuple<UTypes...>&& other) noexcept(
       (std::is_nothrow_assignable_v<Types&, UTypes> && ...)) {
@@ -813,10 +748,10 @@ class tuple {
   }
 
 #if defined(CEXA_HAS_CXX23)
-  template <class... UTypes,
-            class = std::enable_if_t<std::conjunction_v<
-                std::bool_constant<sizeof...(Types) == sizeof...(UTypes)>,
-                std::is_assignable<const Types&, const UTypes&>...>>>
+  template <class... UTypes>
+    requires(sizeof...(Types) == sizeof...(UTypes)) &&
+            std::conjunction_v<
+                std::is_assignable<const Types&, const UTypes&>...>
   KOKKOS_INLINE_FUNCTION constexpr const tuple& operator=(
       const tuple<UTypes...>& other) const
       noexcept((std::is_nothrow_assignable_v<const Types&, const UTypes&> &&
@@ -825,10 +760,9 @@ class tuple {
     return *this;
   }
 
-  template <class... UTypes,
-            class = std::enable_if_t<std::conjunction_v<
-                std::bool_constant<sizeof...(Types) == sizeof...(UTypes)>,
-                std::is_assignable<const Types&, UTypes>...>>>
+  template <class... UTypes>
+    requires(sizeof...(Types) == sizeof...(UTypes)) &&
+            std::conjunction_v<std::is_assignable<const Types&, UTypes>...>
   KOKKOS_INLINE_FUNCTION constexpr const tuple& operator=(
       tuple<UTypes...>&& other) const
       noexcept((std::is_nothrow_assignable_v<const Types&, UTypes> && ...)) {
@@ -837,11 +771,10 @@ class tuple {
   }
 #endif
 
-  template <class U1, class U2,
-            class = std::enable_if_t<std::conjunction_v<
-                std::bool_constant<sizeof...(Types) == 2>,
-                std::is_assignable<T0<Types...>&, const U1&>,
-                std::is_assignable<T1<Types...>&, const U2&>>>>
+  template <class U1, class U2>
+    requires(sizeof...(Types) == 2) &&
+            std::conjunction_v<std::is_assignable<T0<Types...>&, const U1&>,
+                               std::is_assignable<T1<Types...>&, const U2&>>
   constexpr tuple& operator=(const std::pair<U1, U2>& p) noexcept(
       std::is_nothrow_assignable_v<T0<Types...>&, const U1&> &&
       std::is_nothrow_assignable_v<T1<Types...>&, const U2&>) {
@@ -850,11 +783,10 @@ class tuple {
     return *this;
   }
 
-  template <class U1, class U2,
-            class = std::enable_if_t<
-                std::conjunction_v<std::bool_constant<sizeof...(Types) == 2>,
-                                   std::is_assignable<T0<Types...>&, U1>,
-                                   std::is_assignable<T1<Types...>&, U2>>>>
+  template <class U1, class U2>
+    requires(sizeof...(Types) == 2) &&
+            std::conjunction_v<std::is_assignable<T0<Types...>&, U1>,
+                               std::is_assignable<T1<Types...>&, U2>>
   // NOTE: we use forward in order to not move out of references contained
   // inside the pair
   // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
@@ -867,11 +799,12 @@ class tuple {
   }
 
 #if defined(CEXA_HAS_CXX23)
-  template <class U1, class U2,
-            class = std::enable_if_t<std::conjunction_v<
-                std::bool_constant<sizeof...(Types) == 2>,
+  template <class U1, class U2>
+    requires(sizeof...(Types) == 2) &&
+            std::conjunction_v<
                 std::is_assignable<const T0<Types...>&, const U1&>,
-                std::is_assignable<const T1<Types...>&, const U2&>>>>
+                std::is_assignable<const T1<Types...>&, const U2&>>
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
   constexpr const tuple& operator=(const std::pair<U1, U2>& p) const
       noexcept(std::is_nothrow_assignable_v<const T0<Types...>&, const U1&> &&
                std::is_nothrow_assignable_v<const T1<Types...>&, const U2&>) {
@@ -880,14 +813,13 @@ class tuple {
     return *this;
   }
 
-  template <class U1, class U2,
-            class = std::enable_if_t<std::conjunction_v<
-                std::bool_constant<sizeof...(Types) == 2>,
-                std::is_assignable<const T0<Types...>&, U1>,
-                std::is_assignable<const T1<Types...>&, U2>>>>
+  template <class U1, class U2>
+    requires(sizeof...(Types) == 2) &&
+            std::conjunction_v<std::is_assignable<const T0<Types...>&, U1>,
+                               std::is_assignable<const T1<Types...>&, U2>>
   // NOTE: we use forward in order to not move out of references contained
   // inside the pair
-  // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
+  // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved,misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
   constexpr const tuple& operator=(std::pair<U1, U2>&& p) const
       noexcept(std::is_nothrow_assignable_v<const T0<Types...>&, U1> &&
                std::is_nothrow_assignable_v<const T1<Types...>&, U2>) {
@@ -897,34 +829,33 @@ class tuple {
   }
 #endif
 
-  // TODO: use conjunction_v here
-  // NOTE: This overload is introduced in C++23
-  template <class UTuple,
-            class = std::enable_if_t<
-                impl::is_tuple_like_v<UTuple> &&
-                !impl::is_tuple_v<std::remove_cvref_t<UTuple>> &&
-                !impl::is_pair<std::remove_cvref_t<UTuple>>::value &&
-                impl::is_different_from_v<UTuple, tuple> &&
-                !impl::is_subrange_v<UTuple> &&
-                sizeof...(Types) ==
-                    tuple_size<std::remove_reference_t<UTuple>>::value>>
+#if defined(CEXA_HAS_CXX23)
+  template <class UTuple>
+    requires std::conjunction_v<
+        impl::is_tuple_like<UTuple>,
+        std::negation<impl::is_tuple<std::remove_cvref_t<UTuple>>>,
+        std::negation<impl::is_pair<std::remove_cvref_t<UTuple>>>,
+        impl::is_different_from<UTuple, tuple>,
+        std::negation<impl::is_subrange<UTuple>>,
+        std::bool_constant<sizeof...(Types) ==
+                           tuple_size<std::remove_reference_t<UTuple>>::value>>
   // The check for is_assignable is delegated to store.set_all()
   constexpr tuple& operator=(UTuple&& u) {
     values.set(FWD(u));
     return *this;
   }
 
-#if defined(CEXA_HAS_CXX23)
-  template <class UTuple,
-            class = std::enable_if_t<
-                impl::is_tuple_like_v<UTuple> &&
-                !impl::is_tuple_v<std::remove_cvref_t<UTuple>> &&
-                !impl::is_pair<std::remove_cvref_t<UTuple>>::value &&
-                impl::is_different_from_v<UTuple, tuple> &&
-                !impl::is_subrange_v<std::remove_cvref_t<UTuple>> &&
-                sizeof...(Types) ==
-                    tuple_size<std::remove_reference_t<UTuple>>::value>>
+  template <class UTuple>
+    requires std::conjunction_v<
+        impl::is_tuple_like<UTuple>,
+        std::negation<impl::is_tuple<std::remove_cvref_t<UTuple>>>,
+        std::negation<impl::is_pair<std::remove_cvref_t<UTuple>>>,
+        impl::is_different_from<UTuple, tuple>,
+        std::negation<impl::is_subrange<UTuple>>,
+        std::bool_constant<sizeof...(Types) ==
+                           tuple_size<std::remove_reference_t<UTuple>>::value>>
   // The check for is_assignable is delegated to store.set_all()
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
   constexpr const tuple& operator=(UTuple&& u) const {
     values.set(FWD(u));
     return *this;

--- a/tuple/include/impl/tuple.hpp
+++ b/tuple/include/impl/tuple.hpp
@@ -137,7 +137,7 @@ struct store<> {
   KOKKOS_DEFAULTED_FUNCTION constexpr store& operator=(store&&)      = default;
 
 #if defined(CEXA_HAS_CXX23)
-  // NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
+  // NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature,cert-oop54-cpp)
   KOKKOS_INLINE_FUNCTION constexpr const store& operator=(
       const store&) const noexcept {
     return *this;
@@ -199,12 +199,11 @@ struct store<T, Types...> {
   KOKKOS_DEFAULTED_FUNCTION constexpr ~store() = default;
 
   CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
-  template <
-      class U, class... UTypes,
-      class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
-                               !(std::is_same_v<U, T> &&
-                                 (std::is_same_v<UTypes, Types> && ...)) &&
-                               std::is_assignable_v<T&, const U&>>>
+  template <class U, class... UTypes>
+    requires(sizeof...(UTypes) == sizeof...(Types) &&
+             !(std::is_same_v<U, T> &&
+               (std::is_same_v<UTypes, Types> && ...)) &&
+             std::is_assignable_v<T&, const U&>)
   KOKKOS_INLINE_FUNCTION constexpr store& operator=(
       const store<U, UTypes...>& other) {
     value = other.value;
@@ -213,12 +212,11 @@ struct store<T, Types...> {
   }
 
   CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
-  template <
-      class U, class... UTypes,
-      class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
-                               !(std::is_same_v<U, T> &&
-                                 (std::is_same_v<UTypes, Types> && ...)) &&
-                               std::is_assignable_v<T&, U&&>>>
+  template <class U, class... UTypes>
+    requires(sizeof...(UTypes) == sizeof...(Types) &&
+             !(std::is_same_v<U, T> &&
+               (std::is_same_v<UTypes, Types> && ...)) &&
+             std::is_assignable_v<T&, U &&>)
   KOKKOS_INLINE_FUNCTION constexpr store& operator=(
       store<U, UTypes...>&& other) {
     value = FWD(other.value);
@@ -236,8 +234,10 @@ struct store<T, Types...> {
                                     ...))
     requires(std::is_copy_assignable_v<T>)
   {
-    value = other.value;
-    rest  = other.rest;
+    if (this != &other) {
+      value = other.value;
+      rest  = other.rest;
+    }
     return *this;
   }
 
@@ -258,8 +258,10 @@ struct store<T, Types...> {
       const store& other) const
     requires(std::is_copy_assignable_v<const T>)
   {
-    value = other.value;
-    rest  = other.rest;
+    if (this != &other) {
+      value = other.value;
+      rest  = other.rest;
+    }
     return *this;
   }
 
@@ -275,12 +277,11 @@ struct store<T, Types...> {
   }
 
   CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
-  template <
-      class U, class... UTypes,
-      class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
-                               !(std::is_same_v<U, T> &&
-                                 (std::is_same_v<UTypes, Types> && ...)) &&
-                               std::is_assignable_v<const T&, const U&>>>
+  template <class U, class... UTypes>
+    requires(sizeof...(UTypes) == sizeof...(Types) &&
+             !(std::is_same_v<U, T> &&
+               (std::is_same_v<UTypes, Types> && ...)) &&
+             std::is_assignable_v<const T&, const U&>)
   KOKKOS_INLINE_FUNCTION constexpr const store& operator=(
       const store<U, UTypes...>& other) const {
     value = other.value;
@@ -289,12 +290,11 @@ struct store<T, Types...> {
   }
 
   CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
-  template <
-      class U, class... UTypes,
-      class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
-                               !(std::is_same_v<U, T> &&
-                                 (std::is_same_v<UTypes, Types> && ...)) &&
-                               std::is_assignable_v<const T&, U&&>>>
+  template <class U, class... UTypes>
+    requires(sizeof...(UTypes) == sizeof...(Types) &&
+             !(std::is_same_v<U, T> &&
+               (std::is_same_v<UTypes, Types> && ...)) &&
+             std::is_assignable_v<const T&, U &&>)
   KOKKOS_INLINE_FUNCTION constexpr const store& operator=(
       store<U, UTypes...>&& other) const {
     value = FWD(other.value);
@@ -341,15 +341,16 @@ struct store<T, Types...> {
     }
   }
 
-  template <class U, class = std::enable_if_t<std::is_assignable_v<
-                         T&, decltype(std::forward<U>(std::declval<U&&>()))>>>
+  template <class U>
+    requires std::is_assignable_v<
+        T&, decltype(std::forward<U>(std::declval<U&&>()))>
   KOKKOS_INLINE_FUNCTION constexpr void set_all(U&& u) {
     value = u;
   }
 
-  template <class U, class... UTypes,
-            class = std::enable_if_t<std::is_assignable_v<
-                T&, decltype(std::forward<U>(std::declval<U&&>()))>>>
+  template <class U, class... UTypes>
+    requires std::is_assignable_v<
+        T&, decltype(std::forward<U>(std::declval<U&&>()))>
   KOKKOS_INLINE_FUNCTION constexpr void set_all(U&& head, UTypes&&... tail) {
     value = head;
     rest.set_all(FWD(tail)...);
@@ -404,11 +405,11 @@ struct store<T, Types...> {
       const store<U, UTypes...>& rhs) const {
     if (value < rhs.value) {
       return std::weak_ordering::less;
-    } else if (rhs.value < value) {
-      return std::weak_ordering::greater;
-    } else {
-      return static_cast<std::weak_ordering>(rest <=> rhs.rest);
     }
+    if (rhs.value < value) {
+      return std::weak_ordering::greater;
+    }
+    return static_cast<std::weak_ordering>(rest <=> rhs.rest);
   }
 
   CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
@@ -452,6 +453,8 @@ class tuple<> {
   KOKKOS_DEFAULTED_FUNCTION constexpr tuple& operator=(tuple&& u) noexcept =
       default;
 #if defined(CEXA_HAS_CXX23)
+  // We don't care about self assignment since this is an empty class
+  // NOLINTNEXTLINE(cert-oop54-cpp)
   KOKKOS_INLINE_FUNCTION constexpr const tuple& operator=(
       const tuple& u) const noexcept {
     return *this;
@@ -564,28 +567,32 @@ class tuple {
   template <class... UTypes>
   friend class tuple;
 
-  impl::store<Types...> values;
+  impl::store<Types...> m_values;
 
   template <class UTuple, std::size_t... Ints>
   KOKKOS_INLINE_FUNCTION constexpr tuple(converting_tag, UTuple&& u,
                                          std::index_sequence<Ints...>)
-      : values(get<Ints>(FWD(u))...) {}
+      : m_values(get<Ints>(FWD(u))...) {}
 
   template <class UTuple, std::size_t... Ints>
   constexpr tuple(tuple_like_tag, UTuple&& u, std::index_sequence<Ints...>)
-      : values(std::get<Ints>(FWD(u))...) {}
+      : m_values(std::get<Ints>(FWD(u))...) {}
 
  public:
   // tuple.cnstr
   KOKKOS_INLINE_FUNCTION explicit(
-      (!impl::empty_copy_list_initializable_v<Types> ||
+      (!impl::is_empty_copy_list_initializable_v<Types> ||
        ...)) constexpr tuple() noexcept((std::
                                              is_nothrow_default_constructible_v<
                                                  Types> &&
                                          ...))
     requires(std::is_default_constructible_v<Types> && ...)
-      : values{} {}
+      : m_values{} {}
 
+  // NOTE: We have to use sfinae for these constructors, as using a requires
+  // clause would lead to a compile error about the atomic constraint depending
+  // on itself
+  // NOLINTBEGIN(modernize-use-constraints)
   template <class Dummy = void,
             class       = std::enable_if_t<
                 std::is_same_v<Dummy, void> && (sizeof...(Types) >= 1) &&
@@ -596,7 +603,7 @@ class tuple {
                                                                 is_nothrow_copy_constructible_v<
                                                                     Types> &&
                                                             ...))
-      : values(vals...) {}
+      : m_values(vals...) {}
 
   template <
       class... UTypes,
@@ -623,14 +630,14 @@ class tuple {
           std::is_constructible<Types, UTypes>...>>>
   KOKKOS_INLINE_FUNCTION explicit((!std::is_convertible_v<UTypes&&, Types> ||
                                    ...)) constexpr tuple(UTypes&&... args)
-      : values(FWD(args)...) {}
+      : m_values(FWD(args)...) {}
 
   KOKKOS_DEFAULTED_FUNCTION constexpr tuple(const tuple& u) = default;
 
   KOKKOS_INLINE_FUNCTION constexpr tuple(tuple&& u) noexcept(
       (std::is_nothrow_move_assignable_v<Types> && ...))
     requires(std::move_constructible<Types> && ...)
-      : values(std::move(u.values)) {}
+      : m_values(std::move(u.m_values)) {}
 
   template <class... UTypes, CONVERTING_TUPLE_CTOR_CONSTRAINTS(const, &)>
   KOKKOS_INLINE_FUNCTION explicit(
@@ -665,6 +672,7 @@ class tuple {
       : tuple(converting_tag{}, std::move(other),
               std::make_index_sequence<sizeof...(Types)>{}) {}
 #endif
+  // NOLINTEND(modernize-use-constraints)
 
   template <class U1, class U2>
     requires impl::pair_constructible<tuple, const std::pair<U1, U2>&>
@@ -675,7 +683,7 @@ class tuple {
        !std::is_convertible_v<decltype(std::get<1>(FWD(
                                   (std::declval<const std::pair<U1, U2>&>())))),
                               T1<Types...>>)) tuple(const std::pair<U1, U2>& u)
-      : values(u.first, u.second) {}
+      : m_values(u.first, u.second) {}
 
   template <class U1, class U2>
     requires impl::pair_constructible<tuple, std::pair<U1, U2>&&>
@@ -686,7 +694,7 @@ class tuple {
        !std::is_convertible_v<
            decltype(std::get<1>(FWD((std::declval<std::pair<U1, U2>&&>())))),
            T1<Types...>>)) tuple(std::pair<U1, U2>&& u)
-      : values(std::move(u.first), std::move(u.second)) {
+      : m_values(std::move(u.first), std::move(u.second)) {
   }  // TODO: see if we should use forward instead
 
 #if defined(CEXA_HAS_CXX23)
@@ -699,7 +707,7 @@ class tuple {
        !std::is_convertible_v<
            decltype(std::get<1>(FWD((std::declval<std::pair<U1, U2>&>())))),
            T1<Types...>>)) tuple(std::pair<U1, U2>& u)
-      : values(u.first, u.second) {}
+      : m_values(u.first, u.second) {}
 
   template <class U1, class U2>
     requires impl::pair_constructible<tuple, std::pair<U1, U2>&>
@@ -710,7 +718,7 @@ class tuple {
       !std::is_convertible_v<decltype(std::get<1>(FWD(
                                  (std::declval<const std::pair<U1, U2>&&>())))),
                              T1<Types...>>)) tuple(const std::pair<U1, U2>&& u)
-      : values(std::move(u.first), std::move(u.second)) {}
+      : m_values(std::move(u.first), std::move(u.second)) {}
 #endif
 
   template <class UTuple>
@@ -738,7 +746,9 @@ class tuple {
   KOKKOS_INLINE_FUNCTION constexpr const tuple& operator=(const tuple& u) const
     requires(std::is_copy_assignable_v<const Types> && ...)
   {
-    values = u.values;
+    if (this != &u) {
+      m_values = u.m_values;
+    }
     return *this;
   }
 
@@ -746,7 +756,7 @@ class tuple {
       noexcept((std::is_nothrow_move_assignable_v<const Types> && ...))
     requires(std::is_assignable_v<const Types&, Types> && ...)
   {
-    values = std::move(u.values);
+    m_values = std::move(u.m_values);
     return *this;
   }
 #endif
@@ -757,7 +767,7 @@ class tuple {
   KOKKOS_INLINE_FUNCTION constexpr tuple&
   operator=(const tuple<UTypes...>& other) noexcept(
       (std::is_nothrow_assignable_v<Types&, const UTypes&> && ...)) {
-    values = other.values;
+    m_values = other.m_values;
     return *this;
   }
 
@@ -767,7 +777,7 @@ class tuple {
   KOKKOS_INLINE_FUNCTION constexpr tuple&
   operator=(tuple<UTypes...>&& other) noexcept(
       (std::is_nothrow_assignable_v<Types&, UTypes> && ...)) {
-    values = std::move(other.values);
+    m_values = std::move(other.m_values);
     return *this;
   }
 
@@ -780,7 +790,7 @@ class tuple {
       const tuple<UTypes...>& other) const
       noexcept((std::is_nothrow_assignable_v<const Types&, const UTypes&> &&
                 ...)) {
-    values = other.values;
+    m_values = other.m_values;
     return *this;
   }
 
@@ -790,7 +800,7 @@ class tuple {
   KOKKOS_INLINE_FUNCTION constexpr const tuple& operator=(
       tuple<UTypes...>&& other) const
       noexcept((std::is_nothrow_assignable_v<const Types&, UTypes> && ...)) {
-    values = std::move(other.values);
+    m_values = std::move(other.m_values);
     return *this;
   }
 #endif
@@ -802,8 +812,8 @@ class tuple {
   constexpr tuple& operator=(const std::pair<U1, U2>& p) noexcept(
       std::is_nothrow_assignable_v<T0<Types...>&, const U1&> &&
       std::is_nothrow_assignable_v<T1<Types...>&, const U2&>) {
-    values.value      = p.first;
-    values.rest.value = p.second;
+    m_values.value      = p.first;
+    m_values.rest.value = p.second;
     return *this;
   }
 
@@ -817,8 +827,8 @@ class tuple {
   constexpr tuple& operator=(std::pair<U1, U2>&& p) noexcept(
       std::is_nothrow_assignable_v<T0<Types...>&, U1> &&
       std::is_nothrow_assignable_v<T1<Types...>&, U2>) {
-    values.value      = FWD(p.first);
-    values.rest.value = FWD(p.second);
+    m_values.value      = FWD(p.first);
+    m_values.rest.value = FWD(p.second);
     return *this;
   }
 
@@ -832,8 +842,8 @@ class tuple {
   constexpr const tuple& operator=(const std::pair<U1, U2>& p) const
       noexcept(std::is_nothrow_assignable_v<const T0<Types...>&, const U1&> &&
                std::is_nothrow_assignable_v<const T1<Types...>&, const U2&>) {
-    values.value      = p.first;
-    values.rest.value = p.second;
+    m_values.value      = p.first;
+    m_values.rest.value = p.second;
     return *this;
   }
 
@@ -847,8 +857,8 @@ class tuple {
   constexpr const tuple& operator=(std::pair<U1, U2>&& p) const
       noexcept(std::is_nothrow_assignable_v<const T0<Types...>&, U1> &&
                std::is_nothrow_assignable_v<const T1<Types...>&, U2>) {
-    values.value      = FWD(p.first);
-    values.rest.value = FWD(p.second);
+    m_values.value      = FWD(p.first);
+    m_values.rest.value = FWD(p.second);
     return *this;
   }
 #endif
@@ -865,7 +875,7 @@ class tuple {
                            tuple_size<std::remove_reference_t<UTuple>>::value>>
   // The check for is_assignable is delegated to store.set_all()
   constexpr tuple& operator=(UTuple&& u) {
-    values.set(FWD(u));
+    m_values.set(FWD(u));
     return *this;
   }
 
@@ -881,7 +891,7 @@ class tuple {
   // The check for is_assignable is delegated to store.set_all()
   // NOLINTNEXTLINE(misc-unconventional-assign-operator,cppcoreguidelines-c-copy-assignment-signature)
   constexpr const tuple& operator=(UTuple&& u) const {
-    values.set(FWD(u));
+    m_values.set(FWD(u));
     return *this;
   }
 #endif
@@ -889,49 +899,48 @@ class tuple {
 
   KOKKOS_INLINE_FUNCTION constexpr void swap(tuple& rhs) noexcept(
       (std::is_nothrow_swappable_v<Types> && ...)) {
-    return values.swap(rhs.values);
+    return m_values.swap(rhs.m_values);
   }
 
 #if defined(CEXA_HAS_CXX23)
   KOKKOS_INLINE_FUNCTION constexpr void swap(const tuple& rhs) const
       noexcept((std::is_nothrow_swappable_v<const Types> && ...)) {
-    return values.swap(rhs.values);
+    return m_values.swap(rhs.m_values);
   }
 #endif
 
   template <std::size_t I, class... Ts>
-  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
-      (I < sizeof...(Ts)), typename tuple_element<I, tuple<Ts...>>::type&>
-  get(tuple<Ts...>& t) noexcept;
+    requires(I < sizeof...(Ts))
+  KOKKOS_INLINE_FUNCTION friend constexpr tuple_element_t<I, tuple<Ts...>>& get(
+      tuple<Ts...>& t) noexcept;
   template <std::size_t I, class... Ts>
-  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
-      (I < sizeof...(Ts)), typename tuple_element<I, tuple<Ts...>>::type&&>
+    requires(I < sizeof...(Ts))
+  KOKKOS_INLINE_FUNCTION friend constexpr tuple_element_t<I, tuple<Ts...>>&&
   get(tuple<Ts...>&& t) noexcept;
   template <std::size_t I, class... Ts>
-  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
-      (I < sizeof...(Ts)), const typename tuple_element<I, tuple<Ts...>>::type&>
+    requires(I < sizeof...(Ts))
+  KOKKOS_INLINE_FUNCTION friend constexpr const tuple_element_t<I,
+                                                                tuple<Ts...>>&
   get(const tuple<Ts...>& t) noexcept;
   template <std::size_t I, class... Ts>
-  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
-      (I < sizeof...(Ts)),
-      const typename tuple_element<I, tuple<Ts...>>::type&&>
+    requires(I < sizeof...(Ts))
+  KOKKOS_INLINE_FUNCTION friend constexpr const tuple_element_t<I,
+                                                                tuple<Ts...>>&&
   get(const tuple<Ts...>&& t) noexcept;
   template <class T, class... Ts>
-  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
-      (std::is_same_v<T, Ts> || ...), T&>
-  get(tuple<Ts...>& t) noexcept;
+    requires(std::is_same_v<T, Ts> || ...)
+  KOKKOS_INLINE_FUNCTION friend constexpr T& get(tuple<Ts...>& t) noexcept;
   template <class T, class... Ts>
-  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
-      (std::is_same_v<T, Ts> || ...), T&&>
-  get(tuple<Ts...>&& t) noexcept;
+    requires(std::is_same_v<T, Ts> || ...)
+  KOKKOS_INLINE_FUNCTION friend constexpr T&& get(tuple<Ts...>&& t) noexcept;
   template <class T, class... Ts>
-  KOKKOS_INLINE_FUNCTION friend constexpr std::enable_if_t<
-      (std::is_same_v<T, Ts> || ...), const T&>
-  get(const tuple<Ts...>& t) noexcept;
+    requires(std::is_same_v<T, Ts> || ...)
+  KOKKOS_INLINE_FUNCTION friend constexpr const T& get(
+      const tuple<Ts...>& t) noexcept;
   template <class T, class... Ts>
-  KOKKOS_INLINE_FUNCTION friend constexpr const std::enable_if_t<
-      (std::is_same_v<T, Ts> || ...), const T&&>
-  get(const tuple<Ts...>&& t) noexcept;
+    requires(std::is_same_v<T, Ts> || ...)
+  KOKKOS_INLINE_FUNCTION friend constexpr const T&& get(
+      const tuple<Ts...>&& t) noexcept;
 
   // tuple.rel
 #if defined(CEXA_TUPLE_IMPL_USE_SPACESHIP_OPERATOR)
@@ -939,51 +948,51 @@ class tuple {
     requires(sizeof...(Types) == sizeof...(UTypes))
   KOKKOS_INLINE_FUNCTION constexpr auto operator<=>(
       const tuple<UTypes...>& rhs) const {
-    return values <=> rhs.values;
+    return m_values <=> rhs.m_values;
   }
 
   template <class... UTypes>
     requires(sizeof...(Types) == sizeof...(UTypes))
   KOKKOS_INLINE_FUNCTION constexpr bool operator==(
       const tuple<UTypes...>& rhs) const {
-    return (values <=> rhs.values) == 0;
+    return (m_values <=> rhs.m_values) == 0;
   }
 #else
   template <class... UTypes>
     requires(sizeof...(Types) == sizeof...(UTypes))
   KOKKOS_INLINE_FUNCTION constexpr bool operator==(
       const tuple<UTypes...>& rhs) const {
-    return values == rhs.values;
+    return m_values == rhs.m_values;
   }
   template <class... UTypes>
     requires(sizeof...(Types) == sizeof...(UTypes))
   KOKKOS_INLINE_FUNCTION constexpr bool operator!=(
       const tuple<UTypes...>& rhs) const {
-    return !(values == rhs.values);
+    return !(m_values == rhs.m_values);
   }
   template <class... UTypes>
     requires(sizeof...(Types) == sizeof...(UTypes))
   KOKKOS_INLINE_FUNCTION constexpr bool operator<(
       const tuple<UTypes...>& rhs) const {
-    return values < rhs.values;
+    return m_values < rhs.m_values;
   }
   template <class... UTypes>
     requires(sizeof...(Types) == sizeof...(UTypes))
   KOKKOS_INLINE_FUNCTION constexpr bool operator<=(
       const tuple<UTypes...>& rhs) const {
-    return !(rhs.values < values);
+    return !(rhs.m_values < m_values);
   }
   template <class... UTypes>
     requires(sizeof...(Types) == sizeof...(UTypes))
   KOKKOS_INLINE_FUNCTION constexpr bool operator>(
       const tuple<UTypes...>& rhs) const {
-    return rhs.values < values;
+    return rhs.m_values < m_values;
   }
   template <class... UTypes>
     requires(sizeof...(Types) == sizeof...(UTypes))
   KOKKOS_INLINE_FUNCTION constexpr bool operator>=(
       const tuple<UTypes...>& rhs) const {
-    return !(values < rhs.values);
+    return !(m_values < rhs.m_values);
   }
 #endif
 };
@@ -996,64 +1005,61 @@ tuple(std::pair<T1, T2>) -> tuple<T1, T2>;
 
 // tuple.elem
 template <std::size_t I, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (I < sizeof...(Types)), typename tuple_element<I, tuple<Types...>>::type&>
-get(tuple<Types...>& t) noexcept {
-  return t.values.template get_value<I>();
+  requires(I < sizeof...(Types))
+KOKKOS_INLINE_FUNCTION constexpr tuple_element_t<I, tuple<Types...>>& get(
+    tuple<Types...>& t) noexcept {
+  return t.m_values.template get_value<I>();
 }
 template <std::size_t I, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (I < sizeof...(Types)), typename tuple_element<I, tuple<Types...>>::type&&>
+  requires(I < sizeof...(Types))
+KOKKOS_INLINE_FUNCTION constexpr tuple_element_t<I, tuple<Types...>>&&
 // NOTE: this doesn't work with std::move
 // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
 get(tuple<Types...>&& t) noexcept {
   return static_cast<tuple_element_t<I, tuple<Types...>>&&>(
-      t.values.template get_value<I>());
+      t.m_values.template get_value<I>());
 }
 template <std::size_t I, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (I < sizeof...(Types)),
-    const typename tuple_element<I, tuple<Types...>>::type&>
-get(const tuple<Types...>& t) noexcept {
-  return t.values.template get_value<I>();
+  requires(I < sizeof...(Types))
+KOKKOS_INLINE_FUNCTION constexpr const tuple_element_t<I, tuple<Types...>>& get(
+    const tuple<Types...>& t) noexcept {
+  return t.m_values.template get_value<I>();
 }
 template <std::size_t I, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (I < sizeof...(Types)),
-    const typename tuple_element<I, tuple<Types...>>::type&&>
+  requires(I < sizeof...(Types))
+KOKKOS_INLINE_FUNCTION constexpr const tuple_element_t<I, tuple<Types...>>&&
 get(const tuple<Types...>&& t) noexcept {
   return static_cast<const tuple_element_t<I, tuple<Types...>>&&>(
-      t.values.template get_value<I>());
+      t.m_values.template get_value<I>());
 }
 template <class T, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (std::is_same_v<T, Types> || ...), T&>
-get(tuple<Types...>& t) noexcept {
-  return t.values.template get_value<T>();
+  requires(std::is_same_v<T, Types> || ...)
+KOKKOS_INLINE_FUNCTION constexpr T& get(tuple<Types...>& t) noexcept {
+  return t.m_values.template get_value<T>();
 }
 template <class T, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (std::is_same_v<T, Types> || ...), T&&>
+  requires(std::is_same_v<T, Types> || ...)
+KOKKOS_INLINE_FUNCTION constexpr T&&
 // NOTE: this doesn't work with std::move
 // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
 get(tuple<Types...>&& t) noexcept {
-  return static_cast<T&&>(t.values.template get_value<T>());
+  return static_cast<T&&>(t.m_values.template get_value<T>());
 }
 template <class T, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
-    (std::is_same_v<T, Types> || ...), const T&>
-get(const tuple<Types...>& t) noexcept {
-  return t.values.template get_value<T>();
+  requires(std::is_same_v<T, Types> || ...)
+KOKKOS_INLINE_FUNCTION constexpr const T& get(
+    const tuple<Types...>& t) noexcept {
+  return t.m_values.template get_value<T>();
 }
 template <class T, class... Types>
-KOKKOS_INLINE_FUNCTION constexpr const std::enable_if_t<
-    (std::is_same_v<T, Types> || ...), const T&&>
-get(const tuple<Types...>&& t) noexcept {
-  return static_cast<const T&&>(t.values.template get_value<T>());
+  requires(std::is_same_v<T, Types> || ...)
+KOKKOS_INLINE_FUNCTION constexpr const T&& get(
+    const tuple<Types...>&& t) noexcept {
+  return static_cast<const T&&>(t.m_values.template get_value<T>());
 }
 
-template <class... Types,
-          class = std::enable_if_t<(std::is_swappable_v<Types> && ...)>>
+template <class... Types>
+  requires(std::is_swappable_v<Types> && ...)
 KOKKOS_INLINE_FUNCTION constexpr void swap(
     tuple<Types...>& lhs,
     tuple<Types...>& rhs) noexcept((std::is_nothrow_swappable_v<Types> &&
@@ -1062,8 +1068,8 @@ KOKKOS_INLINE_FUNCTION constexpr void swap(
 }
 
 #if defined(CEXA_HAS_CXX23)
-template <class... Types,
-          class = std::enable_if_t<(std::is_swappable_v<const Types> && ...)>>
+template <class... Types>
+  requires(std::is_swappable_v<const Types> && ...)
 KOKKOS_INLINE_FUNCTION constexpr void
 swap(const tuple<Types...>& lhs, const tuple<Types...>& rhs) noexcept(
     (std::is_nothrow_swappable_v<const Types> && ...)) {

--- a/tuple/include/impl/tuple.hpp
+++ b/tuple/include/impl/tuple.hpp
@@ -173,15 +173,19 @@ struct store<T, Types...> {
   T value{};
   store<Types...> rest;
 
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   KOKKOS_DEFAULTED_FUNCTION constexpr store() = default;
 
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   KOKKOS_DEFAULTED_FUNCTION constexpr store(const store& other) = default;
 
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   KOKKOS_INLINE_FUNCTION constexpr store(store&& other) noexcept(
       std::is_nothrow_move_constructible_v<T> &&
       (std::is_nothrow_move_constructible_v<Types> && ...))
       : value(FWD(other.value)), rest(FWD(other.rest)) {}
 
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   template <typename U, typename... UTypes>
     requires(!is_store_v<U> && (!is_store_v<UTypes> && ...))
   KOKKOS_INLINE_FUNCTION constexpr explicit store(
@@ -191,8 +195,10 @@ struct store<T, Types...> {
                                   ...))
       : value(FWD(u)), rest(FWD(args)...) {}
 
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   KOKKOS_DEFAULTED_FUNCTION constexpr ~store() = default;
 
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   template <
       class U, class... UTypes,
       class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
@@ -205,6 +211,8 @@ struct store<T, Types...> {
     rest  = other.rest;
     return *this;
   }
+
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   template <
       class U, class... UTypes,
       class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
@@ -218,6 +226,7 @@ struct store<T, Types...> {
     return *this;
   }
 
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   // FIXME: defaulting this operator leads to compile errors where the
   // generated constructor would be ill-formed
   // NOLINTNEXTLINE(hicpp-use-equals-default, modernize-use-equals-default)
@@ -232,6 +241,7 @@ struct store<T, Types...> {
     return *this;
   }
 
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   KOKKOS_INLINE_FUNCTION constexpr store& operator=(store&& other) noexcept(
       std::is_nothrow_move_assignable_v<T> &&
       (std::is_nothrow_move_assignable_v<Types> && ...))
@@ -243,6 +253,7 @@ struct store<T, Types...> {
   }
 
 #if defined(CEXA_HAS_CXX23)
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   KOKKOS_INLINE_FUNCTION constexpr const store& operator=(
       const store& other) const
     requires(std::is_copy_assignable_v<const T>)
@@ -252,6 +263,7 @@ struct store<T, Types...> {
     return *this;
   }
 
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   KOKKOS_INLINE_FUNCTION constexpr const store& operator=(store&& other) const
       noexcept(std::is_nothrow_move_assignable_v<const T> &&
                (std::is_nothrow_move_assignable_v<const Types> && ...))
@@ -262,6 +274,7 @@ struct store<T, Types...> {
     return *this;
   }
 
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   template <
       class U, class... UTypes,
       class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
@@ -274,6 +287,8 @@ struct store<T, Types...> {
     rest  = other.rest;
     return *this;
   }
+
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   template <
       class U, class... UTypes,
       class = std::enable_if_t<sizeof...(UTypes) == sizeof...(Types) &&
@@ -350,6 +365,7 @@ struct store<T, Types...> {
     set_all(get<Ints>(FWD(u))...);
   }
 
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   KOKKOS_INLINE_FUNCTION constexpr void swap(store& rhs) noexcept(
       std::is_nothrow_swappable_v<T> &&
       (std::is_nothrow_swappable_v<Types> && ...)) {
@@ -359,6 +375,7 @@ struct store<T, Types...> {
   }
 
 #if defined(CEXA_HAS_CXX23)
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   KOKKOS_INLINE_FUNCTION constexpr void swap(const store& rhs) const
       noexcept(std::is_nothrow_swappable_v<const T> &&
                (std::is_nothrow_swappable_v<const Types> && ...)) {
@@ -370,6 +387,7 @@ struct store<T, Types...> {
 #endif
 
 #if defined(CEXA_TUPLE_IMPL_USE_SPACESHIP_OPERATOR)
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   template <class U, class... UTypes>
     requires std::three_way_comparable_with<T, U>
   KOKKOS_INLINE_FUNCTION constexpr auto operator<=>(
@@ -379,6 +397,8 @@ struct store<T, Types...> {
     auto res = value <=> rhs.value;
     return res != 0 ? res : rest <=> rhs.rest;
   }
+
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   template <class U, class... UTypes>
   KOKKOS_INLINE_FUNCTION constexpr std::weak_ordering operator<=>(
       const store<U, UTypes...>& rhs) const {
@@ -390,17 +410,21 @@ struct store<T, Types...> {
       return static_cast<std::weak_ordering>(rest <=> rhs.rest);
     }
   }
+
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   template <class U, class... UTypes>
   KOKKOS_INLINE_FUNCTION constexpr bool operator==(
       const store<U, UTypes...>& rhs) const {
     return operator<=>(rhs) == 0;
   }
 #else
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   template <class U, class... UTypes>
   KOKKOS_INLINE_FUNCTION constexpr bool operator==(
       const store<U, UTypes...>& rhs) const {
     return value == rhs.value && rest == rhs.rest;
   }
+  CEXA_NVCC_HOST_DEVICE_CHECK_DISABLE
   template <class U, class... UTypes>
   KOKKOS_INLINE_FUNCTION constexpr bool operator<(
       const store<U, UTypes...>& rhs) const {

--- a/tuple/include/impl/tuple.hpp
+++ b/tuple/include/impl/tuple.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 #pragma once
 

--- a/tuple/include/impl/tuple_fwd.hpp
+++ b/tuple/include/impl/tuple_fwd.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 #pragma once
 

--- a/tuple/include/tuple.hpp
+++ b/tuple/include/tuple.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 #pragma once
 

--- a/tuple/test/CMakeLists.txt
+++ b/tuple/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CExA-project
+# SPDX-FileCopyrightText: Copyright (C) The CExA project
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 find_package(GTest QUIET)
 if (NOT GTest_FOUND)

--- a/tuple/test/README.md
+++ b/tuple/test/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 CExA-project
+SPDX-FileCopyrightText: Copyright (C) The CExA project
 
 SPDX-License-Identifier: MIT OR Apache-2.0 WITH LLVM-exception
 -->

--- a/tuple/test/main.cpp
+++ b/tuple/test/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 #include <Kokkos_Core.hpp>
 #include <gtest/gtest.h>

--- a/tuple/test/support/MoveOnly.h
+++ b/tuple/test/support/MoveOnly.h
@@ -60,8 +60,8 @@ public:
     template<class T>
     friend void operator,(T, MoveOnly const&) = delete;
 
-  // FIXME: The default std::swap seems to not work on on cuda 12.2-12.4 + gcc 11.2-12.2
-#if defined(KOKKOS_COMPILER_NVCC) && defined(KOKKOS_COMPILER_GNU) && KOKKOS_COMPILER_GNU < 1300
+  // FIXME: The default std::swap seems to not work with nvcc
+#if defined(KOKKOS_COMPILER_NVCC)
     KOKKOS_INLINE_FUNCTION friend constexpr void swap(MoveOnly& lhs, MoveOnly& rhs) {
         auto tmp = lhs.data_;
         lhs.data_ = rhs.data_;

--- a/tuple/test/support/MoveOnly.h
+++ b/tuple/test/support/MoveOnly.h
@@ -60,8 +60,8 @@ public:
     template<class T>
     friend void operator,(T, MoveOnly const&) = delete;
 
-  // FIXME: The default std::swap seems to not work on on cuda 12.2 + gcc 11.2
-#if defined(KOKKOS_COMPILER_NVCC) && defined(KOKKOS_COMPILER_GNU) && KOKKOS_COMPILER_GNU < 1200
+  // FIXME: The default std::swap seems to not work on on cuda 12.2-12.4 + gcc 11.2-12.2
+#if defined(KOKKOS_COMPILER_NVCC) && defined(KOKKOS_COMPILER_GNU) && KOKKOS_COMPILER_GNU < 1300
     KOKKOS_INLINE_FUNCTION friend constexpr void swap(MoveOnly& lhs, MoveOnly& rhs) {
         auto tmp = lhs.data_;
         lhs.data_ = rhs.data_;

--- a/tuple/test/support/cexa_test_macros.hpp
+++ b/tuple/test/support/cexa_test_macros.hpp
@@ -35,14 +35,3 @@
     (defined(KOKKOS_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__))
 #define CEXA_ON_DEVICE
 #endif
-
-#if defined(KOKKOS_ENABLE_CUDA)
-#define CEXA_HOST_DEVICE_NVCC_WARNINGS_PUSH() \
-  _Pragma("nv_diagnostic push")               \
-      _Pragma("nv_diag_suppress 20011,20013,20014,20015")
-
-#define CEXA_HOST_DEVICE_NVCC_WARNINGS_POP() _Pragma("nv_diagnostic pop")
-#else
-#define CEXA_HOST_DEVICE_NVCC_WARNINGS_PUSH()
-#define CEXA_HOST_DEVICE_NVCC_WARNINGS_POP()
-#endif

--- a/tuple/test/support/cexa_test_macros.hpp
+++ b/tuple/test/support/cexa_test_macros.hpp
@@ -34,7 +34,9 @@
     (defined(KOKKOS_ENABLE_HIP) && defined(__HIP_DEVICE_COMPILE__)) || \
     (defined(KOKKOS_ENABLE_SYCL) && defined(__SYCL_DEVICE_ONLY__))
 #define CEXA_ON_DEVICE
+#endif
 
+#if defined(KOKKOS_ENABLE_CUDA)
 #define CEXA_HOST_DEVICE_NVCC_WARNINGS_PUSH() \
   _Pragma("nv_diagnostic push")               \
       _Pragma("nv_diag_suppress 20011,20013,20014,20015")

--- a/tuple/test/support/test_allocator.h
+++ b/tuple/test/support/test_allocator.h
@@ -21,7 +21,7 @@
 #include "test_macros.h"
 
 template <class Alloc>
-TEST_CONSTEXPR_CXX20 inline typename std::allocator_traits<Alloc>::size_type alloc_max_size(Alloc const& a) {
+constexpr inline typename std::allocator_traits<Alloc>::size_type alloc_max_size(Alloc const& a) {
   typedef std::allocator_traits<Alloc> AT;
   return AT::max_size(a);
 }
@@ -144,7 +144,7 @@ public:
     }
   }
 
-  TEST_CONSTEXPR_CXX20 ~test_allocator() TEST_NOEXCEPT {
+  constexpr ~test_allocator() TEST_NOEXCEPT {
     assert(data_ != test_alloc_base::destructed_value);
     assert(id_ != test_alloc_base::destructed_value);
     if (stats_ != nullptr)
@@ -180,7 +180,7 @@ public:
   TEST_CONSTEXPR size_type max_size() const TEST_NOEXCEPT { return UINT_MAX / sizeof(T); }
 
   template <class U>
-  TEST_CONSTEXPR_CXX20 void construct(pointer p, U&& val) {
+  constexpr void construct(pointer p, U&& val) {
     if (stats_ != nullptr)
       ++stats_->construct_count;
 #if TEST_STD_VER > 17
@@ -251,7 +251,7 @@ public:
         id_(a.id_),
         stats_(a.stats_) {}
 
-  TEST_CONSTEXPR_CXX20 ~test_allocator() TEST_NOEXCEPT {
+  constexpr ~test_allocator() TEST_NOEXCEPT {
     data_ = test_alloc_base::destructed_value;
     id_   = test_alloc_base::destructed_value;
   }
@@ -279,8 +279,8 @@ public:
   template <class U>
   TEST_CONSTEXPR_CXX14 other_allocator(const other_allocator<U>& a) : data_(a.data_) {}
 
-  TEST_CONSTEXPR_CXX20 T* allocate(std::size_t n) { return std::allocator<value_type>().allocate(n); }
-  TEST_CONSTEXPR_CXX20 void deallocate(T* p, std::size_t s) { std::allocator<value_type>().deallocate(p, s); }
+  constexpr T* allocate(std::size_t n) { return std::allocator<value_type>().allocate(n); }
+  constexpr void deallocate(T* p, std::size_t s) { std::allocator<value_type>().deallocate(p, s); }
 
   TEST_CONSTEXPR_CXX14 other_allocator select_on_container_copy_construction() const { return other_allocator(-2); }
 
@@ -346,7 +346,7 @@ public:
   TEST_CONSTEXPR TaggingAllocator(const TaggingAllocator<U>&) {}
 
   template <typename... Args>
-  TEST_CONSTEXPR_CXX20 void construct(Tag_X* p, Args&&... args) {
+  constexpr void construct(Tag_X* p, Args&&... args) {
 #if TEST_STD_VER > 17
     std::construct_at(p, Ctor_Tag{}, std::forward<Args>(args)...);
 #else
@@ -355,12 +355,12 @@ public:
   }
 
   template <typename U>
-  TEST_CONSTEXPR_CXX20 void destroy(U* p) {
+  constexpr void destroy(U* p) {
     p->~U();
   }
 
-  TEST_CONSTEXPR_CXX20 T* allocate(std::size_t n) { return std::allocator<T>().allocate(n); }
-  TEST_CONSTEXPR_CXX20 void deallocate(T* p, std::size_t n) { std::allocator<T>().deallocate(p, n); }
+  constexpr T* allocate(std::size_t n) { return std::allocator<T>().allocate(n); }
+  constexpr void deallocate(T* p, std::size_t n) { std::allocator<T>().deallocate(p, n); }
 };
 
 template <std::size_t MaxAllocs>
@@ -369,7 +369,7 @@ struct limited_alloc_handle {
   void* last_alloc_        = nullptr;
 
   template <class T>
-  TEST_CONSTEXPR_CXX20 T* allocate(std::size_t N) {
+  constexpr T* allocate(std::size_t N) {
     if (N + outstanding_ > MaxAllocs)
       TEST_THROW(std::bad_alloc());
     auto alloc  = std::allocator<T>().allocate(N);
@@ -379,7 +379,7 @@ struct limited_alloc_handle {
   }
 
   template <class T>
-  TEST_CONSTEXPR_CXX20 void deallocate(T* ptr, std::size_t N) {
+  constexpr void deallocate(T* ptr, std::size_t N) {
     if (ptr == last_alloc_) {
       last_alloc_ = nullptr;
       assert(outstanding_ >= N);
@@ -399,7 +399,7 @@ public:
     ++block->ref_count;
   }
 
-  TEST_CONSTEXPR_CXX20 ~thread_unsafe_shared_ptr() {
+  constexpr ~thread_unsafe_shared_ptr() {
     --block->ref_count;
     if (block->ref_count != 0)
       return;
@@ -427,11 +427,11 @@ private:
   control_block* block = nullptr;
 
   template <class U, class... Args>
-  friend TEST_CONSTEXPR_CXX20 thread_unsafe_shared_ptr<U> make_thread_unsafe_shared(Args...);
+  friend constexpr thread_unsafe_shared_ptr<U> make_thread_unsafe_shared(Args...);
 };
 
 template <class T, class... Args>
-TEST_CONSTEXPR_CXX20 thread_unsafe_shared_ptr<T> make_thread_unsafe_shared(Args... args) {
+constexpr thread_unsafe_shared_ptr<T> make_thread_unsafe_shared(Args... args) {
   typedef typename thread_unsafe_shared_ptr<T>::control_block control_block_type;
   typedef std::allocator_traits<std::allocator<control_block_type> > allocator_traits;
 
@@ -465,7 +465,7 @@ public:
     typedef limited_allocator<U, N> other;
   };
 
-  TEST_CONSTEXPR_CXX20 limited_allocator() : handle_(detail::make_thread_unsafe_shared<BuffT>()) {}
+  constexpr limited_allocator() : handle_(detail::make_thread_unsafe_shared<BuffT>()) {}
 
   limited_allocator(limited_allocator const&) = default;
 
@@ -474,8 +474,8 @@ public:
 
   limited_allocator& operator=(const limited_allocator&) = delete;
 
-  TEST_CONSTEXPR_CXX20 pointer allocate(size_type n) { return handle_->template allocate<T>(n); }
-  TEST_CONSTEXPR_CXX20 void deallocate(pointer p, size_type n) { handle_->template deallocate<T>(p, n); }
+  constexpr pointer allocate(size_type n) { return handle_->template allocate<T>(n); }
+  constexpr void deallocate(pointer p, size_type n) { handle_->template deallocate<T>(p, n); }
   TEST_CONSTEXPR size_type max_size() const { return N; }
   TEST_CONSTEXPR const BuffT* getHandle() const { return handle_.get(); }
 };

--- a/tuple/test/tuple.apply/CMakeLists.txt
+++ b/tuple/test/tuple.apply/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CExA-project
+# SPDX-FileCopyrightText: Copyright (C) The CExA project
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 add_tuple_test(apply.pass.cpp)
 add_tuple_test(apply_extended_types.pass.cpp)

--- a/tuple/test/tuple.apply/apply.pass.cpp
+++ b/tuple/test/tuple.apply/apply.pass.cpp
@@ -246,8 +246,8 @@ namespace ReturnTypeTest {
         using RawInvokeResult = decltype(f(index<Func>{}));
         static_assert(std::is_same<RawInvokeResult, Expect>::value, "");
         using FnType = RawInvokeResult (*) (index<Func>);
-        FnType fn = f;
-        cexa::tuple<index<Func>> t; ((void)t);
+        [[maybe_unused]] FnType fn = f;
+        [[maybe_unused]] cexa::tuple<index<Func>> t;
         using InvokeResult = decltype(cexa::apply(fn, t));
         static_assert(std::is_same<InvokeResult, Expect>::value, "");
     }

--- a/tuple/test/tuple.apply/apply.pass.cpp
+++ b/tuple/test/tuple.apply/apply.pass.cpp
@@ -195,7 +195,7 @@ KOKKOS_INLINE_FUNCTION void test_noexcept()
     {
         // test that the functions noexcept-ness is propagated
         using Tup = cexa::tuple<int, const char*, long>;
-        Tup t;
+        [[maybe_unused]] Tup t;
 // #if TEST_STD_VER >= 23
 //         ASSERT_NOEXCEPT(cexa::apply(nec, t));
 // #else
@@ -206,7 +206,7 @@ KOKKOS_INLINE_FUNCTION void test_noexcept()
     {
         // test that the noexcept-ness of the argument conversions is checked.
         using Tup = cexa::tuple<NothrowMoveable, int>;
-        Tup t;
+        [[maybe_unused]] Tup t;
         ASSERT_NOT_NOEXCEPT(cexa::apply(nec, t));
 // #if TEST_STD_VER >= 23
 //         ASSERT_NOEXCEPT(cexa::apply(nec, std::move(t)));

--- a/tuple/test/tuple.apply/apply.pass.cpp
+++ b/tuple/test/tuple.apply/apply.pass.cpp
@@ -46,21 +46,21 @@ KOKKOS_INLINE_FUNCTION void test_constexpr_evaluation()
     {
         using Tup = cexa::tuple<>;
         using Fn = int(&)();
-        constexpr Tup t;
+        [[maybe_unused]] constexpr Tup t;
         static_assert(cexa::apply(static_cast<Fn>(constexpr_sum_fn), t) == 0, "");
         static_assert(cexa::apply(sum_obj, t) == 0, "");
     }
     {
         using Tup = cexa::tuple<int>;
         using Fn = int(&)(int);
-        constexpr Tup t(42);
+        [[maybe_unused]] constexpr Tup t(42);
         static_assert(cexa::apply(static_cast<Fn>(constexpr_sum_fn), t) == 42, "");
         static_assert(cexa::apply(sum_obj, t) == 42, "");
     }
     {
         using Tup = cexa::tuple<int, long>;
         using Fn = int(&)(int, int);
-        constexpr Tup t(42, 101);
+        [[maybe_unused]] constexpr Tup t(42, 101);
         static_assert(cexa::apply(static_cast<Fn>(constexpr_sum_fn), t) == 143, "");
         static_assert(cexa::apply(sum_obj, t) == 143, "");
     }
@@ -74,7 +74,7 @@ KOKKOS_INLINE_FUNCTION void test_constexpr_evaluation()
     {
         using Tup = cexa::tuple<int, long, int>;
         using Fn = int(&)(int, int, int);
-        constexpr Tup t(42, 101, -1);
+        [[maybe_unused]] constexpr Tup t(42, 101, -1);
         static_assert(cexa::apply(static_cast<Fn>(constexpr_sum_fn), t) == 142, "");
         static_assert(cexa::apply(sum_obj, t) == 142, "");
     }

--- a/tuple/test/tuple.apply/apply.pass.cpp
+++ b/tuple/test/tuple.apply/apply.pass.cpp
@@ -196,11 +196,9 @@ KOKKOS_INLINE_FUNCTION void test_noexcept()
         // test that the functions noexcept-ness is propagated
         using Tup = cexa::tuple<int, const char*, long>;
         [[maybe_unused]] Tup t;
-// #if TEST_STD_VER >= 23
-//         ASSERT_NOEXCEPT(cexa::apply(nec, t));
-// #else
-        LIBCPP_ASSERT_NOEXCEPT(cexa::apply(nec, t));
-// #endif
+#if TEST_STD_VER >= 23
+        ASSERT_NOEXCEPT(cexa::apply(nec, t));
+#endif
         ASSERT_NOT_NOEXCEPT(cexa::apply(tc, t));
     }
     {
@@ -208,11 +206,9 @@ KOKKOS_INLINE_FUNCTION void test_noexcept()
         using Tup = cexa::tuple<NothrowMoveable, int>;
         [[maybe_unused]] Tup t;
         ASSERT_NOT_NOEXCEPT(cexa::apply(nec, t));
-// #if TEST_STD_VER >= 23
-//         ASSERT_NOEXCEPT(cexa::apply(nec, std::move(t)));
-// #else
-        LIBCPP_ASSERT_NOEXCEPT(cexa::apply(nec, std::move(t)));
-// #endif
+#if TEST_STD_VER >= 23
+        ASSERT_NOEXCEPT(cexa::apply(nec, std::move(t)));
+#endif
     }
 }
 

--- a/tuple/test/tuple.apply/apply.pass.cpp
+++ b/tuple/test/tuple.apply/apply.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.apply/apply_extended_types.pass.cpp
+++ b/tuple/test/tuple.apply/apply_extended_types.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.apply/apply_large_arity.pass.cpp
+++ b/tuple/test/tuple.apply/apply_large_arity.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.apply/make_from_tuple.pass.cpp
+++ b/tuple/test/tuple.apply/make_from_tuple.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/CMakeLists.txt
+++ b/tuple/test/tuple.assign/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CExA-project
+# SPDX-FileCopyrightText: Copyright (C) The CExA project
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 add_tuple_test(const_convert_copy.pass.cpp)
 add_tuple_test(const_convert_move.pass.cpp)

--- a/tuple/test/tuple.assign/const_convert_copy.pass.cpp
+++ b/tuple/test/tuple.assign/const_convert_copy.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/const_convert_move.pass.cpp
+++ b/tuple/test/tuple.assign/const_convert_move.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/const_copy.pass.cpp
+++ b/tuple/test/tuple.assign/const_copy.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/const_move.pass.cpp
+++ b/tuple/test/tuple.assign/const_move.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/const_pair.pass.cpp
+++ b/tuple/test/tuple.assign/const_pair.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/const_pair_copy.pass.cpp
+++ b/tuple/test/tuple.assign/const_pair_copy.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/const_pair_move.pass.cpp
+++ b/tuple/test/tuple.assign/const_pair_move.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/convert_copy.pass.cpp
+++ b/tuple/test/tuple.assign/convert_copy.pass.cpp
@@ -49,7 +49,7 @@ struct PotentiallyThrowingCopyAssignable {
     KOKKOS_INLINE_FUNCTION PotentiallyThrowingCopyAssignable& operator=(PotentiallyThrowingCopyAssignable const&) { return *this; }
 };
 
-KOKKOS_INLINE_FUNCTION TEST_CONSTEXPR_CXX20
+KOKKOS_INLINE_FUNCTION constexpr
 bool test()
 {
     {
@@ -109,9 +109,7 @@ bool test()
 // clang-format off
 CEXA_TEST(tuple_assign, convert_copy, (
     test();
-#if TEST_STD_VER >= 20
     static_assert(test());
-#endif
 
     {
         using T = cexa::tuple<int, NonAssignable>;

--- a/tuple/test/tuple.assign/convert_copy.pass.cpp
+++ b/tuple/test/tuple.assign/convert_copy.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/convert_move.pass.cpp
+++ b/tuple/test/tuple.assign/convert_move.pass.cpp
@@ -93,7 +93,7 @@ struct TrackMove
     bool moved_from;
 };
 
-KOKKOS_INLINE_FUNCTION TEST_CONSTEXPR_CXX20
+KOKKOS_INLINE_FUNCTION constexpr
 bool test()
 {
     {
@@ -143,9 +143,7 @@ TEST(tuple_assign, convert_move_host) {
 // clang-format off
 CEXA_TEST(tuple_assign, convert_move, (
     test();
-#if TEST_STD_VER >= 20
     static_assert(test());
-#endif
 
     {
         typedef cexa::tuple<long, char, D> T0;

--- a/tuple/test/tuple.assign/convert_move.pass.cpp
+++ b/tuple/test/tuple.assign/convert_move.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/copy.pass.cpp
+++ b/tuple/test/tuple.assign/copy.pass.cpp
@@ -50,13 +50,12 @@ struct CopyAssignableInt {
   CopyAssignableInt& operator=(int&) { return *this; }
 };
 
-constexpr
-bool test()
+KOKKOS_INLINE_FUNCTION constexpr bool test()
 {
     {
         typedef cexa::tuple<> T;
         T t0;
-        T t;
+        [[maybe_unused]] T t;
         t = t0;
     }
     {

--- a/tuple/test/tuple.assign/copy.pass.cpp
+++ b/tuple/test/tuple.assign/copy.pass.cpp
@@ -50,7 +50,7 @@ struct CopyAssignableInt {
   CopyAssignableInt& operator=(int&) { return *this; }
 };
 
-TEST_CONSTEXPR_CXX20
+constexpr
 bool test()
 {
     {
@@ -107,9 +107,7 @@ TEST(tuple_assign, copy_host) {
 // clang-format off
 CEXA_TEST(tuple_assign, copy, (
     test();
-#if TEST_STD_VER >= 20
     static_assert(test());
-#endif
 
     {
         // test that the implicitly generated copy assignment operator
@@ -120,7 +118,6 @@ CEXA_TEST(tuple_assign, copy, (
     {
         using T = cexa::tuple<int, NonAssignable>;
         static_assert(!std::is_copy_assignable<T>::value, "");
-        static_assert(!std::is_copy_assignable<cexa::impl::store_<std::unique_ptr<int>>>::value, "");
     }
     {
         using T = cexa::tuple<int, CopyAssignable>;

--- a/tuple/test/tuple.assign/copy.pass.cpp
+++ b/tuple/test/tuple.assign/copy.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/derived_from_tuple_like.pass.cpp
+++ b/tuple/test/tuple.assign/derived_from_tuple_like.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/laziness.pass.cpp
+++ b/tuple/test/tuple.assign/laziness.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/move.pass.cpp
+++ b/tuple/test/tuple.assign/move.pass.cpp
@@ -62,7 +62,7 @@ struct CountAssign {
   KOKKOS_INLINE_FUNCTION CountAssign& operator=(CountAssign&&) { ++moved; return *this; }
 };
 
-KOKKOS_INLINE_FUNCTION TEST_CONSTEXPR_CXX20
+KOKKOS_INLINE_FUNCTION constexpr
 bool test()
 {
     {
@@ -116,10 +116,7 @@ bool test()
 // clang-format off
 CEXA_TEST(tuple_assign, move, (
     test();
-    // TODO: see if this is also constexpr in 17
-#if TEST_STD_VER >= 20
     static_assert(test());
-#endif
 
     {
         // test that the implicitly generated move assignment operator

--- a/tuple/test/tuple.assign/move.pass.cpp
+++ b/tuple/test/tuple.assign/move.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.assign/move_pair.pass.cpp
+++ b/tuple/test/tuple.assign/move_pair.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/CMakeLists.txt
+++ b/tuple/test/tuple.cnstr/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CExA-project
+# SPDX-FileCopyrightText: Copyright (C) The CExA project
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 add_tuple_test(default.pass.cpp)
 add_tuple_test(dtor.pass.cpp)

--- a/tuple/test/tuple.cnstr/PR20855_tuple_ref_binding_diagnostics.pass.cpp
+++ b/tuple/test/tuple.cnstr/PR20855_tuple_ref_binding_diagnostics.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/PR22806_constrain_tuple_like_ctor.pass.cpp
+++ b/tuple/test/tuple.cnstr/PR22806_constrain_tuple_like_ctor.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/PR23256_constrain_UTypes_ctor.pass.cpp
+++ b/tuple/test/tuple.cnstr/PR23256_constrain_UTypes_ctor.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/PR27684_contains_ref_to_incomplete_type.pass.cpp
+++ b/tuple/test/tuple.cnstr/PR27684_contains_ref_to_incomplete_type.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/PR31384.pass.cpp
+++ b/tuple/test/tuple.cnstr/PR31384.pass.cpp
@@ -22,6 +22,7 @@
 #include <support/cexa_test_macros.hpp>
 #include <support/test_macros.h>
 
+#if !defined(KOKKOS_COMPILER_GNU) || (KOKKOS_COMPILER_GNU < 14)
 #if defined(CEXA_ON_DEVICE)
 __device__ int count = 0;
 #else
@@ -101,3 +102,4 @@ CEXA_TEST(tuple_cnstr, PR31384, (
   count = 0;
 ))
 // clang-format on
+#endif

--- a/tuple/test/tuple.cnstr/PR31384.pass.cpp
+++ b/tuple/test/tuple.cnstr/PR31384.pass.cpp
@@ -78,10 +78,7 @@ CEXA_TEST(tuple_cnstr, PR31384, (
   }
   count = 0;
   {
-    // FIXME: there are no explicit constructors if not in C++20, this might be the reason this static_assert fails in C++17
-    #if defined(CEXA_HAS_CXX20)
     static_assert(!std::is_convertible<ExplicitDerived<int>, cexa::tuple<Explicit>>::value, "");
-    #endif
     // FIXME: This fails with nvcc, the element-wise conversion constructor is chosen
     #if !defined(KOKKOS_COMPILER_NVCC)
     ExplicitDerived<int> d{42};

--- a/tuple/test/tuple.cnstr/PR31384.pass.cpp
+++ b/tuple/test/tuple.cnstr/PR31384.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/UTypes.pass.cpp
+++ b/tuple/test/tuple.cnstr/UTypes.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/cnstr_with_any.compile.pass.cpp
+++ b/tuple/test/tuple.cnstr/cnstr_with_any.compile.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/const_Types.pass.cpp
+++ b/tuple/test/tuple.cnstr/const_Types.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/const_move_pair.pass.cpp
+++ b/tuple/test/tuple.cnstr/const_move_pair.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/const_pair.pass.cpp
+++ b/tuple/test/tuple.cnstr/const_pair.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/convert_const_move.pass.cpp
+++ b/tuple/test/tuple.cnstr/convert_const_move.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/convert_copy.pass.cpp
+++ b/tuple/test/tuple.cnstr/convert_copy.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/convert_move.pass.cpp
+++ b/tuple/test/tuple.cnstr/convert_move.pass.cpp
@@ -116,7 +116,6 @@ CEXA_TEST(tuple_cnstr, convert_move, (
     }
 ))
 
-    CEXA_HOST_DEVICE_NVCC_WARNINGS_PUSH()
 TEST(tuple_cnstr, convert_move_host) {
     typedef cexa::tuple<long, char, std::unique_ptr<D>> T0;
     typedef cexa::tuple<long long, int, std::unique_ptr<B>> T1;
@@ -126,5 +125,4 @@ TEST(tuple_cnstr, convert_move_host) {
     CEXA_EXPECT_EQ(cexa::get<1>(t1), int('a'));
     CEXA_EXPECT_EQ(cexa::get<2>(t1)->id_, 3);
 }
-    CEXA_HOST_DEVICE_NVCC_WARNINGS_POP()
 // clang-format on

--- a/tuple/test/tuple.cnstr/convert_move.pass.cpp
+++ b/tuple/test/tuple.cnstr/convert_move.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/convert_non_const_copy.pass.cpp
+++ b/tuple/test/tuple.cnstr/convert_non_const_copy.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/copy.pass.cpp
+++ b/tuple/test/tuple.cnstr/copy.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/deduct.pass.cpp
+++ b/tuple/test/tuple.cnstr/deduct.pass.cpp
@@ -48,8 +48,11 @@ CEXA_TEST(tuple_cnstr, deduct_primary, (
   // const auto AT = std::allocator_arg;
   { // Testing (1)
     int x = 101;
+    // FIXME: The CTAD for single argument constructors fails with nvcc
+#if !defined(KOKKOS_COMPILER_NVCC)
     [[maybe_unused]] cexa::tuple t1(42);
     ASSERT_SAME_TYPE(decltype(t1), cexa::tuple<int>);
+#endif
     [[maybe_unused]] cexa::tuple t2(x, 0.0, nullptr);
     ASSERT_SAME_TYPE(decltype(t2), cexa::tuple<int, double, decltype(nullptr)>);
   }
@@ -57,15 +60,14 @@ CEXA_TEST(tuple_cnstr, deduct_primary, (
     using T = ExplicitTestTypes::TestType;
     static_assert(!std::is_convertible<T const&, T>::value, "");
 
+#if !defined(KOKKOS_COMPILER_NVCC)
     [[maybe_unused]] cexa::tuple t1(T{});
     ASSERT_SAME_TYPE(decltype(t1), cexa::tuple<T>);
+#endif
 
-    // FIXME: This CTAD fails on gcc for some reasons
-  #if !defined(KOKKOS_COMPILER_GNU) || KOKKOS_COMPILER_GNU >= 1300
     const T v{};
     [[maybe_unused]] cexa::tuple t2(T{}, 101l, v);
     ASSERT_SAME_TYPE(decltype(t2), cexa::tuple<T, long, T>);
-  #endif
   }
   // TODO: Add when allocator_arg constructors are supported
   // { // Testing (4)

--- a/tuple/test/tuple.cnstr/deduct.pass.cpp
+++ b/tuple/test/tuple.cnstr/deduct.pass.cpp
@@ -65,9 +65,12 @@ CEXA_TEST(tuple_cnstr, deduct_primary, (
     ASSERT_SAME_TYPE(decltype(t1), cexa::tuple<T>);
 #endif
 
+// FIXME: This fails with old nvcc versions (tested with 12.2)
+#if !defined(KOKKOS_COMPILER_NVCC)
     const T v{};
     [[maybe_unused]] cexa::tuple t2(T{}, 101l, v);
     ASSERT_SAME_TYPE(decltype(t2), cexa::tuple<T, long, T>);
+#endif
   }
   // TODO: Add when allocator_arg constructors are supported
   // { // Testing (4)

--- a/tuple/test/tuple.cnstr/deduct.pass.cpp
+++ b/tuple/test/tuple.cnstr/deduct.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/default.pass.cpp
+++ b/tuple/test/tuple.cnstr/default.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/dtor.pass.cpp
+++ b/tuple/test/tuple.cnstr/dtor.pass.cpp
@@ -38,7 +38,7 @@ struct TrackDtor {
   KOKKOS_INLINE_FUNCTION TEST_CONSTEXPR_CXX14 TrackDtor(TrackDtor&& that) : count_(that.count_) {
     that.count_ = nullptr;
   }
-  KOKKOS_INLINE_FUNCTION TEST_CONSTEXPR_CXX20 ~TrackDtor() {
+  KOKKOS_INLINE_FUNCTION constexpr ~TrackDtor() {
     if (count_) ++*count_;
   }
 };

--- a/tuple/test/tuple.cnstr/dtor.pass.cpp
+++ b/tuple/test/tuple.cnstr/dtor.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/empty_tuple_trivial.compile.pass.cpp
+++ b/tuple/test/tuple.cnstr/empty_tuple_trivial.compile.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/move.pass.cpp
+++ b/tuple/test/tuple.cnstr/move.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/move_pair.pass.cpp
+++ b/tuple/test/tuple.cnstr/move_pair.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/non_const_pair.pass.cpp
+++ b/tuple/test/tuple.cnstr/non_const_pair.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/recursion_depth.pass.cpp
+++ b/tuple/test/tuple.cnstr/recursion_depth.pass.cpp
@@ -40,13 +40,11 @@ KOKKOS_INLINE_FUNCTION constexpr void CreateTuple(std::index_sequence<I...>) {
   TargetTuple t5;                                          // default constructor
   (void)t1; (void)t2; (void)t3; (void)t4; (void)t5;
 
-#if TEST_STD_VER >= 20
   t1 = tuple;                                              // converting assignment from &
   t1 = static_cast<LargeTuple const&>(tuple);              // converting assignment from const&
   t1 = std::move(tuple);                                   // converting assignment from &&
   t1 = static_cast<LargeTuple const&&>(tuple);             // converting assignment from const&&
   swap(t1, t2);                                            // swap
-#endif
   // t1 == tuple;                                          // comparison does not work yet (we blow the constexpr stack)
 }
 

--- a/tuple/test/tuple.cnstr/recursion_depth.pass.cpp
+++ b/tuple/test/tuple.cnstr/recursion_depth.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.cnstr/test_lazy_sfinae.pass.cpp
+++ b/tuple/test/tuple.cnstr/test_lazy_sfinae.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.creation/CMakeLists.txt
+++ b/tuple/test/tuple.creation/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CExA-project
+# SPDX-FileCopyrightText: Copyright (C) The CExA project
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 add_tuple_test(forward_as_tuple.pass.cpp)
 add_tuple_test(make_tuple.pass.cpp)

--- a/tuple/test/tuple.creation/forward_as_tuple.pass.cpp
+++ b/tuple/test/tuple.creation/forward_as_tuple.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.creation/make_tuple.pass.cpp
+++ b/tuple/test/tuple.creation/make_tuple.pass.cpp
@@ -64,7 +64,7 @@ bool device_test()
     return true;
 }
 
-TEST_CONSTEXPR_CXX20
+constexpr
 bool test()
 {
     int i = 0;
@@ -89,9 +89,7 @@ bool test()
 
 TEST(host_tuple_creation, make_tuple_host) {
     test();
-#if TEST_STD_VER >= 20
     static_assert(test());
-#endif
 }
 
 // clang-format off

--- a/tuple/test/tuple.creation/make_tuple.pass.cpp
+++ b/tuple/test/tuple.creation/make_tuple.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.creation/tie.pass.cpp
+++ b/tuple/test/tuple.creation/tie.pass.cpp
@@ -39,11 +39,9 @@ KOKKOS_INLINE_FUNCTION constexpr bool test_tie()
         CEXA_EXPECT_EQ(&cexa::get<1>(res), &cexa::ignore);
         CEXA_EXPECT_EQ(&cexa::get<2>(res), &f);
 
-#if TEST_STD_VER >= 20
         res = cexa::make_tuple(101, nullptr, -1.0);
         CEXA_EXPECT_EQ(i, 101);
         CEXA_EXPECT_EQ(f, -1.0);
-#endif
     }
     return true;
 }

--- a/tuple/test/tuple.creation/tie.pass.cpp
+++ b/tuple/test/tuple.creation/tie.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.creation/tuple_cat.pass.cpp
+++ b/tuple/test/tuple.creation/tuple_cat.pass.cpp
@@ -57,18 +57,19 @@ KOKKOS_INLINE_FUNCTION constexpr bool test_tuple_cat_with_unconstrained_construc
     CEXA_EXPECT_EQ(cexa::get<0>(tup).data, 7);
   }
   {
-    auto tup_src = cexa::tuple(Unconstrained(8));
+    // FIXME: we cannot rely on CTAD here since single argument CTAD fails with nvcc
+    auto tup_src = cexa::tuple<Unconstrained>(Unconstrained(8));
     auto tup     = cexa::tuple_cat(tup_src);
     ASSERT_SAME_TYPE(decltype(tup), cexa::tuple<Unconstrained>);
     CEXA_EXPECT_EQ(cexa::get<0>(tup).data, 8);
   }
   {
-    auto tup = cexa::tuple_cat(cexa::tuple(Unconstrained(9)));
+    auto tup = cexa::tuple_cat(cexa::tuple<Unconstrained>(Unconstrained(9)));
     ASSERT_SAME_TYPE(decltype(tup), cexa::tuple<Unconstrained>);
     CEXA_EXPECT_EQ(cexa::get<0>(tup).data, 9);
   }
   {
-    auto tup = cexa::tuple_cat(cexa::tuple(Unconstrained(10)), cexa::tuple());
+    auto tup = cexa::tuple_cat(cexa::tuple<Unconstrained>(Unconstrained(10)), cexa::tuple());
     ASSERT_SAME_TYPE(decltype(tup), cexa::tuple<Unconstrained>);
     CEXA_EXPECT_EQ(cexa::get<0>(tup).data, 10);
   }

--- a/tuple/test/tuple.creation/tuple_cat.pass.cpp
+++ b/tuple/test/tuple.creation/tuple_cat.pass.cpp
@@ -78,12 +78,10 @@ KOKKOS_INLINE_FUNCTION constexpr bool test_tuple_cat_with_unconstrained_construc
 
 TEST(host_tuple_creation, tuple_cat_host) {
     {
-        cexa::tuple<> t = cexa::tuple_cat(std::array<int, 0>());
-        ((void)t); // Prevent unused warning
+        [[maybe_unused]] cexa::tuple<> t = cexa::tuple_cat(std::array<int, 0>());
     }
     {
-        constexpr cexa::tuple<> t = cexa::tuple_cat(std::array<int, 0>());
-        ((void)t); // Prevent unused warning
+        [[maybe_unused]] constexpr cexa::tuple<> t = cexa::tuple_cat(std::array<int, 0>());
     }
     {
         cexa::tuple<int, int, int> t = cexa::tuple_cat(std::array<int, 3>());

--- a/tuple/test/tuple.creation/tuple_cat.pass.cpp
+++ b/tuple/test/tuple.creation/tuple_cat.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.elem/CMakeLists.txt
+++ b/tuple/test/tuple.elem/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CExA-project
+# SPDX-FileCopyrightText: Copyright (C) The CExA project
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 add_tuple_test(get_const.pass.cpp)
 add_tuple_test(get_const_rv.pass.cpp)

--- a/tuple/test/tuple.elem/get_const.pass.cpp
+++ b/tuple/test/tuple.elem/get_const.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.elem/get_const_rv.pass.cpp
+++ b/tuple/test/tuple.elem/get_const_rv.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.elem/get_non_const.pass.cpp
+++ b/tuple/test/tuple.elem/get_non_const.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.elem/get_rv.pass.cpp
+++ b/tuple/test/tuple.elem/get_rv.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.elem/tuple.by.type.pass.cpp
+++ b/tuple/test/tuple.elem/tuple.by.type.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.extra/CMakeLists.txt
+++ b/tuple/test/tuple.extra/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CExA-project
+# SPDX-FileCopyrightText: Copyright (C) The CExA project
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 add_tuple_test(host_device_boundary.pass.cpp)
 add_tuple_test(host_device_memcpy.pass.cpp)

--- a/tuple/test/tuple.extra/host_device_boundary.pass.cpp
+++ b/tuple/test/tuple.extra/host_device_boundary.pass.cpp
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2026 CExA-project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
-//
-// This is a modified version of the tuple tests from llvm's libcxx tests,
-// below is the original copyright statement
+
 #include <tuple.hpp>
 #include <support/cexa_test_macros.hpp>
 #include <support/test_macros.h>

--- a/tuple/test/tuple.extra/host_device_boundary.pass.cpp
+++ b/tuple/test/tuple.extra/host_device_boundary.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 
 #include <tuple.hpp>

--- a/tuple/test/tuple.extra/host_device_memcpy.pass.cpp
+++ b/tuple/test/tuple.extra/host_device_memcpy.pass.cpp
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2026 CExA-project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
-//
-// This is a modified version of the tuple tests from llvm's libcxx tests,
-// below is the original copyright statement
+
 #include <tuple.hpp>
 #include <support/cexa_test_macros.hpp>
 #include <support/test_macros.h>

--- a/tuple/test/tuple.extra/host_device_memcpy.pass.cpp
+++ b/tuple/test/tuple.extra/host_device_memcpy.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 
 #include <tuple.hpp>

--- a/tuple/test/tuple.general/CMakeLists.txt
+++ b/tuple/test/tuple.general/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CExA-project
+# SPDX-FileCopyrightText: Copyright (C) The CExA project
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 add_tuple_compile_test(ignore.include.compile.pass.cpp)
 add_tuple_test(ignore.pass.cpp)

--- a/tuple/test/tuple.general/ignore.include.compile.pass.cpp
+++ b/tuple/test/tuple.general/ignore.include.compile.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.general/ignore.pass.cpp
+++ b/tuple/test/tuple.general/ignore.pass.cpp
@@ -51,7 +51,7 @@ KOKKOS_INLINE_FUNCTION constexpr bool test() {
   { // Test that cexa::ignore provides copy/move assignment
     auto copy  = cexa::ignore;
     copy       = cexa::ignore;
-    auto moved = cexa::ignore;
+    [[maybe_unused]] auto moved = cexa::ignore;
     moved      = std::move(copy);
   }
 

--- a/tuple/test/tuple.general/ignore.pass.cpp
+++ b/tuple/test/tuple.general/ignore.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.general/tuple.smartptr.pass.cpp
+++ b/tuple/test/tuple.general/tuple.smartptr.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.helper/CMakeLists.txt
+++ b/tuple/test/tuple.helper/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CExA-project
+# SPDX-FileCopyrightText: Copyright (C) The CExA project
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 add_tuple_compile_test(tuple.include.array.pass.cpp)
 add_tuple_compile_test(tuple.include.ranges.pass.cpp)

--- a/tuple/test/tuple.helper/tuple.include.array.pass.cpp
+++ b/tuple/test/tuple.helper/tuple.include.array.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.helper/tuple.include.ranges.pass.cpp
+++ b/tuple/test/tuple.helper/tuple.include.ranges.pass.cpp
@@ -20,7 +20,6 @@
 
 #include <tuple.hpp>
 
-#if defined(CEXA_HAS_CXX20)
 #include <ranges>
 
 // Note: make sure to not include `<utility>` (or any other header including `<utility>`) because it also makes some
@@ -69,6 +68,3 @@ int main(int, char**) {
 
   return 0;
 }
-#else
-int main() {}
-#endif

--- a/tuple/test/tuple.helper/tuple.include.ranges.pass.cpp
+++ b/tuple/test/tuple.helper/tuple.include.ranges.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.helper/tuple.include.utility.pass.cpp
+++ b/tuple/test/tuple.helper/tuple.include.utility.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.helper/tuple_element.pass.cpp
+++ b/tuple/test/tuple.helper/tuple_element.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.helper/tuple_size.pass.cpp
+++ b/tuple/test/tuple.helper/tuple_size.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.helper/tuple_size_incomplete.pass.cpp
+++ b/tuple/test/tuple.helper/tuple_size_incomplete.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.helper/tuple_size_structured_bindings.pass.cpp
+++ b/tuple/test/tuple.helper/tuple_size_structured_bindings.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.helper/tuple_size_v.pass.cpp
+++ b/tuple/test/tuple.helper/tuple_size_v.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.helper/tuple_size_value_sfinae.pass.cpp
+++ b/tuple/test/tuple.helper/tuple_size_value_sfinae.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.rel/CMakeLists.txt
+++ b/tuple/test/tuple.rel/CMakeLists.txt
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 add_tuple_test(eq.pass.cpp)
 add_tuple_test(lt.pass.cpp)
-add_tuple_compile_test(size_incompatible_three_way.compile.pass.cpp) # FIXME: c++ >= 20 only
-add_tuple_test(three_way.pass.cpp) # FIXME: c++ >= 20 only
+add_tuple_compile_test(size_incompatible_three_way.compile.pass.cpp)
+add_tuple_test(three_way.pass.cpp)

--- a/tuple/test/tuple.rel/CMakeLists.txt
+++ b/tuple/test/tuple.rel/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CExA-project
+# SPDX-FileCopyrightText: Copyright (C) The CExA project
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 add_tuple_test(eq.pass.cpp)
 add_tuple_test(lt.pass.cpp)

--- a/tuple/test/tuple.rel/eq.pass.cpp
+++ b/tuple/test/tuple.rel/eq.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.rel/lt.pass.cpp
+++ b/tuple/test/tuple.rel/lt.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.rel/size_incompatible_three_way.compile.pass.cpp
+++ b/tuple/test/tuple.rel/size_incompatible_three_way.compile.pass.cpp
@@ -24,7 +24,6 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
 #include <tuple.hpp>
-#if defined(CEXA_HAS_CXX20)
 #include <array>
 #include <complex>
 #include <ranges>
@@ -50,6 +49,5 @@ static_assert(!can_compare<T1, std::complex<double>>);
 static_assert(!can_compare<std::complex<double>, T1>);
 static_assert(!can_compare<T1P, std::ranges::subrange<int*>>);
 static_assert(!can_compare<std::ranges::subrange<int*>, T1P>);
-#endif
 
 int main() {}

--- a/tuple/test/tuple.rel/size_incompatible_three_way.compile.pass.cpp
+++ b/tuple/test/tuple.rel/size_incompatible_three_way.compile.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.rel/three_way.pass.cpp
+++ b/tuple/test/tuple.rel/three_way.pass.cpp
@@ -24,7 +24,7 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
 #include <tuple.hpp>
-#if defined(CEXA_HAS_CXX20)
+#if defined(CEXA_TUPLE_IMPL_USE_SPACESHIP_OPERATOR)
 #include <support/cexa_test_macros.hpp>
 #include <support/test_macros.h>
 
@@ -39,12 +39,12 @@ TEST_MSVC_DIAGNOSTIC_IGNORED(4242 4244)
 
 // A custom three-way result type
 struct CustomEquality {
-  friend constexpr bool operator==(const CustomEquality&, int) noexcept { return true; }
-  friend constexpr bool operator<(const CustomEquality&, int) noexcept { return false; }
-  friend constexpr bool operator<(int, const CustomEquality&) noexcept { return false; }
+  KOKKOS_FUNCTION friend constexpr bool operator==(const CustomEquality&, int) noexcept { return true; }
+  KOKKOS_FUNCTION friend constexpr bool operator<(const CustomEquality&, int) noexcept { return false; }
+  KOKKOS_FUNCTION friend constexpr bool operator<(int, const CustomEquality&) noexcept { return false; }
 };
 
-constexpr bool test() {
+KOKKOS_FUNCTION constexpr bool test() {
   struct WeakSpaceship {
     constexpr bool operator==(const WeakSpaceship&) const { return true; }
     constexpr std::weak_ordering operator<=>(const WeakSpaceship&) const { return std::weak_ordering::equivalent; }
@@ -122,21 +122,21 @@ constexpr bool test() {
   {
     typedef cexa::tuple<float> T1;
     typedef cexa::tuple<double> T2;
-    constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+    constexpr double nan = Kokkos::Experimental::quiet_NaN_v<double>;
     // Comparisons with NaN and non-NaN are non-constexpr in GCC, so both sides must be NaN
     CEXA_EXPECT_EQ((T1(nan) <=> T2(nan)), std::partial_ordering::unordered);
   }
   {
     typedef cexa::tuple<double, double> T1;
     typedef cexa::tuple<float, float> T2;
-    constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+    constexpr double nan = Kokkos::Experimental::quiet_NaN_v<double>;
     CEXA_EXPECT_EQ((T1(nan, 2) <=> T2(nan, 2)), std::partial_ordering::unordered);
     CEXA_EXPECT_EQ((T1(1, nan) <=> T2(1, nan)), std::partial_ordering::unordered);
   }
   {
     typedef cexa::tuple<double, float, float> T1;
     typedef cexa::tuple<double, double, float> T2;
-    constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+    constexpr double nan = Kokkos::Experimental::quiet_NaN_v<double>;
     CEXA_EXPECT_EQ((T1(nan, 2, 3) <=> T2(nan, 2, 3)), std::partial_ordering::unordered);
     CEXA_EXPECT_EQ((T1(1, nan, 3) <=> T2(1, nan, 3)), std::partial_ordering::unordered);
     CEXA_EXPECT_EQ((T1(1, 2, nan) <=> T2(1, 2, nan)), std::partial_ordering::unordered);
@@ -210,14 +210,14 @@ constexpr bool test() {
     {
       typedef cexa::tuple<double> T1;
       typedef cexa::tuple<int> T2;
-      constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+      constexpr double nan = Kokkos::Experimental::quiet_NaN_v<double>;
       ASSERT_SAME_TYPE(decltype(T1() <=> T2()), std::partial_ordering);
       CEXA_EXPECT_EQ((T1(nan) <=> T2(1)), std::partial_ordering::unordered);
     }
     {
       typedef cexa::tuple<double, double> T1;
       typedef cexa::tuple<int, int> T2;
-      constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+      constexpr double nan = Kokkos::Experimental::quiet_NaN_v<double>;
       ASSERT_SAME_TYPE(decltype(T1() <=> T2()), std::partial_ordering);
       CEXA_EXPECT_EQ((T1(nan, 2) <=> T2(1, 2)), std::partial_ordering::unordered);
       CEXA_EXPECT_EQ((T1(1, nan) <=> T2(1, 2)), std::partial_ordering::unordered);
@@ -225,7 +225,7 @@ constexpr bool test() {
     {
       typedef cexa::tuple<double, double, double> T1;
       typedef cexa::tuple<int, int, int> T2;
-      constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+      constexpr double nan = Kokkos::Experimental::quiet_NaN_v<double>;
       ASSERT_SAME_TYPE(decltype(T1() <=> T2()), std::partial_ordering);
       CEXA_EXPECT_EQ((T1(nan, 2, 3) <=> T2(1, 2, 3)), std::partial_ordering::unordered);
       CEXA_EXPECT_EQ((T1(1, nan, 3) <=> T2(1, 2, 3)), std::partial_ordering::unordered);
@@ -243,4 +243,3 @@ CEXA_TEST(tuple_rel, three_way, (
 ))
 // clang-format on
 #endif
-

--- a/tuple/test/tuple.rel/three_way.pass.cpp
+++ b/tuple/test/tuple.rel/three_way.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.special/CMakeLists.txt
+++ b/tuple/test/tuple.special/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CExA-project
+# SPDX-FileCopyrightText: Copyright (C) The CExA project
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 add_tuple_test(non_member_swap.pass.cpp)
 add_tuple_test(non_member_swap_const.pass.cpp)

--- a/tuple/test/tuple.special/non_member_swap.pass.cpp
+++ b/tuple/test/tuple.special/non_member_swap.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.special/non_member_swap_const.pass.cpp
+++ b/tuple/test/tuple.special/non_member_swap_const.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.swap/CMakeLists.txt
+++ b/tuple/test/tuple.swap/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 CExA-project
+# SPDX-FileCopyrightText: Copyright (C) The CExA project
 # SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 add_tuple_test(member_swap.pass.cpp)
 add_tuple_test(member_swap_const.pass.cpp)

--- a/tuple/test/tuple.swap/member_swap.pass.cpp
+++ b/tuple/test/tuple.swap/member_swap.pass.cpp
@@ -24,7 +24,7 @@
 #include <support/test_macros.h>
 #include <support/MoveOnly.h>
 
-KOKKOS_INLINE_FUNCTION TEST_CONSTEXPR_CXX20
+KOKKOS_INLINE_FUNCTION constexpr
 bool test()
 {
     {

--- a/tuple/test/tuple.swap/member_swap.pass.cpp
+++ b/tuple/test/tuple.swap/member_swap.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,

--- a/tuple/test/tuple.swap/member_swap_const.pass.cpp
+++ b/tuple/test/tuple.swap/member_swap_const.pass.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 CExA-project
+// SPDX-FileCopyrightText: Copyright (C) The CExA project
 // SPDX-License-Identifier: MIT or Apache-2.0 with LLVM-exception
 //
 // This is a modified version of the tuple tests from llvm's libcxx tests,


### PR DESCRIPTION
This PR updates the tuple to C++20, what's been done:
- remove the `CEXA_HAS_CXX20` macro
- unguard test code inside `#ifdef TEST_STD_VER >= 20`
- get rid of the helper classes for conditionally deleting the assignment operators and use `requires` instead
- replace some sfinae with a dummy template parameter with concepts
- replace some fallback type traits with the C++20 equivalent from the stdlib
- silence the host function called from host device function warnings when using nvcc
- fix the clang tidy warnings in the implementation (warnings in the tests are not handled by this PR)